### PR TITLE
Make approve in MiniMeTokenERC20 actually approve

### DIFF
--- a/contracts/standard/arbitration/ArbitrableTokens/MiniMeTokenERC20.sol
+++ b/contracts/standard/arbitration/ArbitrableTokens/MiniMeTokenERC20.sol
@@ -24,5 +24,9 @@ contract MiniMeTokenERC20 is MiniMeToken {
         if (isContract(controller)) {
             require(TokenController(controller).onApprove(msg.sender, _spender, _amount));
         }
+
+        allowed[msg.sender][_spender] = _amount;
+        Approval(msg.sender, _spender, _amount);
+        return true;
     }
 }


### PR DESCRIPTION
`approve` function in MiniMeTokenERC20 successfully removes forcing current allowance to be 0, but also removes actual approval, this PR fixes that.