### PR TITLE
Add constructor to MiniMeTokenERC20

### DIFF
--- a/contracts/standard/arbitration/ArbitrableTokens/MiniMeTokenERC20.sol
+++ b/contracts/standard/arbitration/ArbitrableTokens/MiniMeTokenERC20.sol
@@ -11,6 +11,35 @@ pragma solidity ^0.4.18;
 import "minimetoken/contracts/MiniMeToken.sol";
 
 contract MiniMeTokenERC20 is MiniMeToken {
+
+    /** @notice Constructor to create a MiniMeTokenERC20
+     *  @param _tokenFactory The address of the MiniMeTokenFactory contract that will
+     *   create the Clone token contracts, the token factory needs to be deployed first
+     *  @param _parentToken Address of the parent token, set to 0x0 if it is a new token
+     *  @param _parentSnapShotBlock Block of the parent token that will determine the
+     *   initial distribution of the clone token, set to 0 if it is a new token
+     *  @param _tokenName Name of the new token
+     *  @param _decimalUnits Number of decimals of the new token
+     *  @param _tokenSymbol Token Symbol for the new token
+     *  @param _transfersEnabled If true, tokens will be able to be transferred
+     */
+    function MiniMeTokenERC20(
+        address _tokenFactory,
+        address _parentToken,
+        uint _parentSnapShotBlock,
+        string _tokenName,
+        uint8 _decimalUnits,
+        string _tokenSymbol,
+        bool _transfersEnabled
+    )  MiniMeToken(
+        _tokenFactory,
+        _parentToken,
+        _parentSnapShotBlock,
+        _tokenName,
+        _decimalUnits,
+        _tokenSymbol,
+        _transfersEnabled
+    ) public {}
     
     /** @notice `msg.sender` approves `_spender` to spend `_amount` tokens on its behalf.
       * This is a ERC20 compliant version.


### PR DESCRIPTION
Currently `MiniMeTokenERC20` doesn't implement any constructor and doesn't pass arguments to base constructor, making it abstract and rendering any attempts to deploy it fail.
This PR adds constructor calling base constructor with all supplied arguments, so it can actually be used.