### PR TITLE
Fixes Typo in Import Statement Which Causes Compilation Error

### DIFF
--- a/contracts/standard/rng/BlockhashRNGFallback.sol
+++ b/contracts/standard/rng/BlockhashRNGFallback.sol
@@ -9,7 +9,7 @@
  */
 pragma solidity ^0.4.15;
  
-import "./BlockHashRNG.sol";
+import "./BlockhashRNG.sol";
 
 /** Random Number Generator returning the blockhash with a backup behaviour.
  *  Allows saving the random number for use in the future. 


### PR DESCRIPTION
**Steps to reproduce:**

`cd kleros-interaction`
`truffle test`

**Output:**

<pre>Using network 'development'.

Error: Could not find /home/u/Repos/kleros-interaction/contracts/standard/rng/BlockHashRNG.sol from any sources; imported from /home/u/Repos/kleros-interaction/contracts/standard/rng/BlockhashRNGFallback.sol
    at /usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/index.js:76:1
    at /usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/~/async/internal/onlyOnce.js:12:1
    at next (/usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/~/async/whilst.js:68:1)
    at /usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/index.js:64:1
    at /usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/fs.js:85:1
    at /usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/~/async/internal/once.js:12:1
    at replenish (/usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/~/async/internal/eachOfLimit.js:59:1)
    at iterateeCallback (/usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/~/async/internal/eachOfLimit.js:49:1)
    at /usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/~/async/internal/onlyOnce.js:12:1
    at ReadFileContext.callback (/usr/lib/node_modules/truffle/build/webpack:/~/truffle-resolver/fs.js:81:1)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:420:13)</pre>


**Reason:** 
`BlockhashRNGFallback.sol` imports `"./BlockHashRNG.sol"` however there is no `./BlockHashRNG.sol` but `./BlockhashRNG.sol`.

**Fix:** 
Edited import statement from to `import "./BlockhashRNG.sol";` 