### PR TITLE
Added Missing Arguments to Base Constructor in ArbitrableBlacklist

### DIFF
--- a/contracts/standard/permission/ArbitrableBlacklist.sol
+++ b/contracts/standard/permission/ArbitrableBlacklist.sol
@@ -60,7 +60,7 @@ contract ArbitrableBlacklist is PermissionInterface, Arbitrable {
      *  @param _stake The amount in weis of deposit required for a submission or a challenge.
      *  @param _timeToChallenge The time in second, others parties have to challenge 
      */
-    function ArbitrableBlacklist(Arbitrator _arbitrator, bytes _arbitratorExtraData, uint _stake, uint _timeToChallenge) public {
+    function ArbitrableBlacklist(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash, uint _stake, uint _timeToChallenge) Arbitrable(_arbitrator, _arbitratorExtraData, _contractHash) public {
         arbitrator=_arbitrator;
         arbitratorExtraData=_arbitratorExtraData;
         stake=_stake;


### PR DESCRIPTION
`ArbitrableBlacklist` constructor was called erroneously. Base constructor `Arbitrable` needs `address arbitrator`, `bytes arbitratorExtraData` and `bytes32 contractHash` which was missing.