### PR TITLE
Eliminating Some Compiler Warnings

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,15 +8,15 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  constructor() {
+  constructor() public {
     owner = msg.sender;
   }
 
-  function setCompleted(uint completed) restricted {
+  function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;
   }
 
-  function upgrade(address new_address) restricted {
+  function upgrade(address new_address) public restricted {
     Migrations upgraded = Migrations(new_address);
     upgraded.setCompleted(last_completed_migration);
   }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() {
+  constructor() {
     owner = msg.sender;
   }
 

--- a/contracts/standard/arbitration/AppealableArbitrator.sol
+++ b/contracts/standard/arbitration/AppealableArbitrator.sol
@@ -1,1 +1,2 @@
 // TODO: Create a class allowing appeal to another arbitrator.
+pragma solidity ^0.4.24;

--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -65,7 +65,7 @@ contract Arbitrable{
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
      *  @param _ruling Ruling given by the arbitrator. Note that 0 is reserved for "Not able/wanting to make a decision".
      */
-    function rule(uint _disputeID, uint _ruling) onlyArbitrator {
+    function rule(uint _disputeID, uint _ruling) public onlyArbitrator {
         emit Ruling(Arbitrator(msg.sender),_disputeID,_ruling);
 
         executeRuling(_disputeID,_ruling);

--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -19,23 +19,23 @@ import "./Arbitrator.sol";
 contract Arbitrable{
     Arbitrator public arbitrator;
     bytes public arbitratorExtraData; // Extra data to require particular dispute and appeal behaviour.
-    
+
     modifier onlyArbitrator {require(msg.sender==address(arbitrator)); _;}
-    
+
     /** @dev To be raised when a dispute is created. The main purpose of this event is to let the arbitrator know the meaning ruling IDs.
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
      *  @param _rulingOptions Map ruling IDs to short description of the ruling in a CSV format using ";" as a delimiter. Note that ruling IDs start a 1. For example "Send funds to buyer;Send funds to seller", means that ruling 1 will make the contract send funds to the buyer and 2 to the seller.
      */
     event Dispute(Arbitrator indexed _arbitrator, uint indexed _disputeID, string _rulingOptions);
-    
+
     /** @dev To be raised when a ruling is given.
      *  @param _arbitrator The arbitrator giving the ruling.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
      *  @param _ruling The ruling which was given.
      */
     event Ruling(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
-    
+
     /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due tp gas considerations).
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -43,23 +43,23 @@ contract Arbitrable{
      *  @param _evidence A link to evidence or if it is short the evidence itself. Can be web link ("http://X"), IPFS ("ipfs:/X") or another storing service (using the URI, see https://en.wikipedia.org/wiki/Uniform_Resource_Identifier ). One usecase of short evidence is to include the hash of the plain English contract.
      */
     event Evidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, address _party, string _evidence);
-    
+
     /** @dev To be emmited at contract creation. Contains the hash of the plain text contract. This will allow any party to show what was the original contract.
      *  This event is used as cheap way of storing it.
      *  @param _contractHash Keccak256 hash of the plain text contract.
      */
     event ContractHash(bytes32 _contractHash);
-    
+
     /** @dev Constructor. Choose the arbitrator.
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _contractHash Keccak256 hash of the plain text contract.
      */
-    function Arbitrable(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash) {
+    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash) {
         arbitrator=_arbitrator;
 	arbitratorExtraData=_arbitratorExtraData;
         ContractHash(_contractHash);
     }
-    
+
     /** @dev Give a ruling for a dispute. Must be called by the arbitrator.
      *  The purpose of this function is to ensure that the address calling it has the right to rule on the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -67,11 +67,11 @@ contract Arbitrable{
      */
     function rule(uint _disputeID, uint _ruling) onlyArbitrator {
         Ruling(Arbitrator(msg.sender),_disputeID,_ruling);
-        
+
         executeRuling(_disputeID,_ruling);
     }
-    
-    
+
+
     /** @dev Execute a ruling of a dispute.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
      *  @param _ruling Ruling given by the arbitrator. Note that 0 is reserved for "Not able/wanting to make a decision".

--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -55,9 +55,9 @@ contract Arbitrable{
      *  @param _contractHash Keccak256 hash of the plain text contract.
      */
     constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash) {
-        arbitrator=_arbitrator;
-	arbitratorExtraData=_arbitratorExtraData;
-        ContractHash(_contractHash);
+        arbitrator = _arbitrator;
+        arbitratorExtraData = _arbitratorExtraData;
+        emit ContractHash(_contractHash);
     }
 
     /** @dev Give a ruling for a dispute. Must be called by the arbitrator.
@@ -66,7 +66,7 @@ contract Arbitrable{
      *  @param _ruling Ruling given by the arbitrator. Note that 0 is reserved for "Not able/wanting to make a decision".
      */
     function rule(uint _disputeID, uint _ruling) onlyArbitrator {
-        Ruling(Arbitrator(msg.sender),_disputeID,_ruling);
+        emit Ruling(Arbitrator(msg.sender),_disputeID,_ruling);
 
         executeRuling(_disputeID,_ruling);
     }

--- a/contracts/standard/arbitration/ArbitrableDeposit.sol
+++ b/contracts/standard/arbitration/ArbitrableDeposit.sol
@@ -65,7 +65,7 @@ contract ArbitrableDeposit is Arbitrable {
 
     /** @dev Owner deposit to contract. To be called when the owner makes a deposit.
      */
-    function deposit(uint _amount) onlyOwner {
+    function deposit(uint _amount) public onlyOwner {
         amount += _amount;
         address(this).transfer(_amount);
     }
@@ -73,7 +73,7 @@ contract ArbitrableDeposit is Arbitrable {
     /** @dev File a claim against owner. To be called when someone makes a claim.
      *  @param _claimAmount The proposed claim amount by the claimant.
      */
-    function makeClaim(uint _claimAmount) onlyNotOwner {
+    function makeClaim(uint _claimAmount) public onlyNotOwner {
         require(_claimAmount >= 0 && _claimAmount <= amount);
         claimant = msg.sender;
         claimAmount = _claimAmount;
@@ -86,7 +86,7 @@ contract ArbitrableDeposit is Arbitrable {
      *  a response.
      *  @param _responseAmount The counter-offer amount the Owner proposes to a claimant.
      */
-    function claimResponse(uint _responseAmount) onlyOwner {
+    function claimResponse(uint _responseAmount) public onlyOwner {
         require(_responseAmount >= 0 && _responseAmount <= claimDepositAmount);
         claimResponseAmount = _responseAmount;
         if (_responseAmount == claimDepositAmount) {
@@ -103,7 +103,7 @@ contract ArbitrableDeposit is Arbitrable {
      *  Note that the arbitrator can have createDispute throw, which will make this function throw and therefore lead to a party being timed-out.
      *  This is not a vulnerability as the arbitrator can rule in favor of one party anyway.
      */
-    function payArbitrationFeeByOwner() payable onlyOwner{
+    function payArbitrationFeeByOwner() public payable onlyOwner{
         uint arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
         ownerFee += msg.value;
         require(ownerFee == arbitrationCost); // Require that the total pay at least the arbitration cost.
@@ -122,7 +122,7 @@ contract ArbitrableDeposit is Arbitrable {
     /** @dev Pay the arbitration fee to raise a dispute. To be called by the claimant. UNTRUSTED.
      *  Note that this function mirror payArbitrationFeeByOwner.
      */
-    function payArbitrationFeeByClaimant() payable onlyClaimant {
+    function payArbitrationFeeByClaimant() public payable onlyClaimant {
         uint arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
         claimantFee += msg.value;
         require(claimantFee == arbitrationCost); // Require that the total pay at least the arbitration cost.
@@ -148,7 +148,7 @@ contract ArbitrableDeposit is Arbitrable {
 
     /** @dev Reimburse owner if claimant fails to pay the fee.
      */
-    function timeOutByOwner() onlyOwner {
+    function timeOutByOwner() public onlyOwner {
         require(status==Status.WaitingClaimant);
         require(now >= lastInteraction + timeout);
 
@@ -157,7 +157,7 @@ contract ArbitrableDeposit is Arbitrable {
 
     /** @dev Pay claimant if owner fails to pay the fee.
      */
-    function timeOutByClaimant() onlyClaimant {
+    function timeOutByClaimant() public onlyClaimant {
         require(status==Status.WaitingOwner);
         require(now >= lastInteraction+timeout);
 

--- a/contracts/standard/arbitration/ArbitrableDeposit.sol
+++ b/contracts/standard/arbitration/ArbitrableDeposit.sol
@@ -113,7 +113,7 @@ contract ArbitrableDeposit is Arbitrable {
         if (claimantFee < arbitrationCost) { // The claimant still has to pay.
         // This can also happens if he has paid, but arbitrationCost has increased.
             status = Status.WaitingClaimant;
-            HasToPayFee(Party.Claimant);
+            emit HasToPayFee(Party.Claimant);
         } else { // The claimant has also paid the fee. We create the dispute
             raiseDispute(arbitrationCost);
         }
@@ -128,10 +128,10 @@ contract ArbitrableDeposit is Arbitrable {
         require(claimantFee == arbitrationCost); // Require that the total pay at least the arbitration cost.
         require(status<Status.DisputeCreated); // Make sure a dispute has not been created yet.
 
-        lastInteraction=now;
+        lastInteraction = now;
         if (ownerFee < arbitrationCost) { // The owner still has to pay. This can also happens if he has paid, but arbitrationCost has increased.
             status = Status.WaitingOwner;
-            HasToPayFee(Party.Claimant);
+            emit HasToPayFee(Party.Claimant);
         } else { // The owner has also paid the fee. We create the dispute
             raiseDispute(arbitrationCost);
         }
@@ -143,7 +143,7 @@ contract ArbitrableDeposit is Arbitrable {
     function raiseDispute(uint _arbitrationCost) internal {
         status = Status.DisputeCreated;
         disputeID = arbitrator.createDispute.value(_arbitrationCost)(AMOUNT_OF_CHOICES,arbitratorExtraData);
-        Dispute(arbitrator,disputeID,RULING_OPTIONS);
+        emit Dispute(arbitrator,disputeID,RULING_OPTIONS);
     }
 
     /** @dev Reimburse owner if claimant fails to pay the fee.

--- a/contracts/standard/arbitration/ArbitrableTokens/FundingVault.sol
+++ b/contracts/standard/arbitration/ArbitrableTokens/FundingVault.sol
@@ -60,7 +60,7 @@ contract FundingVault is Arbitrable {
      *  @param _additionalTimeToWithdraw The time in seconds which is added per ‱ of tokens disputing the claim.
      *  @param _timeout Maximum time to pay arbitration fees after the other side did.
      */
-    function FundingVault(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash, address _team, address _token, address _funder, uint _disputeThreshold, uint _claimToWithdrawTime, uint _additionalTimeToWithdraw, uint _timeout) public Arbitrable(_arbitrator,_arbitratorExtraData,_contractHash) {
+    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash, address _team, address _token, address _funder, uint _disputeThreshold, uint _claimToWithdrawTime, uint _additionalTimeToWithdraw, uint _timeout) public Arbitrable(_arbitrator,_arbitratorExtraData,_contractHash) {
         team=_team;
         token=MiniMeToken(_token);
         funder=_funder;

--- a/contracts/standard/arbitration/ArbitrableTokens/LockedToken.sol
+++ b/contracts/standard/arbitration/ArbitrableTokens/LockedToken.sol
@@ -18,16 +18,16 @@ contract LockedToken is MintableToken {
     uint constant LOCK_DIVISOR = 1E6;
     mapping (address => uint) public lastUnlock; // Last time tokens were unlocked.
     mapping (address => uint) public amountLocked; // The amount of tokens locked.
-    
+
     /** @dev Constructor.
      *  @param _lockMultiplierPerMillionPerMonth The amount we must multiply the locked portion each month.
      *  It is (1-unlockRatioPerYear)^(1/12) * 1E6. Note that we should compute that offchain to avoid integer rounding.
      *  So for 10% unlock per year, it is 991258.
      */
-    function LockedToken(uint _lockMultiplierPerMillionPerMonth) public {
+    constructor(uint _lockMultiplierPerMillionPerMonth) public {
         lockMultiplierPerMillionPerMonth=_lockMultiplierPerMillionPerMonth;
     }
-    
+
     /** @dev Mint tokens.
      *  @param _to The address that will receive the minted tokens.
      *  @param _amount The amount of tokens to mint.
@@ -39,8 +39,8 @@ contract LockedToken is MintableToken {
         amountLocked[_to].add(_amount);
         return true;
     }
-    
-    /** @dev Unlock the tokens which can. 
+
+    /** @dev Unlock the tokens which can.
      *  Note that this function is O(log(t)) where t is the last time of unlock.
      *  You can call partiallUnlock with a maxUnlock to avoid gas issues.
      *  But note that it is likely to never be necessary as the cost of this function, if not high even for multiple years.
@@ -49,8 +49,8 @@ contract LockedToken is MintableToken {
     function unlock(address _to) public {
         partialUnlock(_to,uint(-1));
     }
-    
-    /** @dev Unlock the tokens which can. 
+
+    /** @dev Unlock the tokens which can.
      *  This function is O(_maxUnlock). You may need to call it multiple times.
      *  @param _to The address to unlock tokens from.
      */
@@ -65,7 +65,7 @@ contract LockedToken is MintableToken {
             amountLocked[_to]=newLocked;
         }
     }
-    
+
     /** @dev Transfer token for a specified address.
      *  @param _to The address to transfer to.
      *  @param _value The amount to be transferred.
@@ -73,11 +73,11 @@ contract LockedToken is MintableToken {
     function transfer(address _to, uint256 _value) public returns (bool) {
         unlock(msg.sender);
         require(balances[msg.sender].sub(amountLocked[msg.sender])>=_value);
-        
+
         assert(super.transfer(_to,_value));
         return true;
     }
-    
+
     /** @dev Transfer tokens from one address to another
      *  @param _from address The address which you want to send tokens from
      *  @param _to address The address which you want to transfer to
@@ -86,11 +86,9 @@ contract LockedToken is MintableToken {
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
         unlock(_from);
         require(balances[_from].sub(amountLocked[_from])>=_value);
-        
+
         assert(super.transferFrom(_from,_to,_value));
         return true;
     }
-    
+
 }
-
-

--- a/contracts/standard/arbitration/ArbitrableTokens/MiniMeTokenERC20.sol
+++ b/contracts/standard/arbitration/ArbitrableTokens/MiniMeTokenERC20.sol
@@ -23,7 +23,7 @@ contract MiniMeTokenERC20 is MiniMeToken {
      *  @param _tokenSymbol Token Symbol for the new token
      *  @param _transfersEnabled If true, tokens will be able to be transferred
      */
-    function MiniMeTokenERC20(
+    constructor(
         address _tokenFactory,
         address _parentToken,
         uint _parentSnapShotBlock,
@@ -40,7 +40,7 @@ contract MiniMeTokenERC20 is MiniMeToken {
         _tokenSymbol,
         _transfersEnabled
     ) public {}
-    
+
     /** @notice `msg.sender` approves `_spender` to spend `_amount` tokens on its behalf.
       * This is a ERC20 compliant version.
       * @param _spender The address of the account able to transfer the tokens

--- a/contracts/standard/arbitration/ArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/ArbitrableTransaction.sol
@@ -15,10 +15,10 @@ import "./TwoPartyArbitrable.sol";
  */
  contract ArbitrableTransaction is TwoPartyArbitrable {
     string constant RULING_OPTIONS = "Reimburse partyA;Pay partyB";
-    
+
     uint public amount; // Amount sent by party A.
-    
-    
+
+
     /** @dev Constructor. Choose the arbitrator. Should be called by party A (the payer).
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _hashContract Keccak hash of the plain English contract.
@@ -26,7 +26,7 @@ import "./TwoPartyArbitrable.sol";
      *  @param _partyB The recipient of the transaction.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
      */
-    function ArbitrableTransaction(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData) TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData) payable {
+    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData) TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData) payable {
         amount+=msg.value;
     }
 
@@ -36,7 +36,7 @@ import "./TwoPartyArbitrable.sol";
         partyB.transfer(amount);
         amount=0;
     }
-    
+
     /** @dev Reimburse party A. To be called if the good or service can't be fully provided.
      *  @param _amountReimbursed Amount to reimburse in wei.
      */
@@ -45,7 +45,7 @@ import "./TwoPartyArbitrable.sol";
         partyA.transfer(_amountReimbursed);
         amount-=_amountReimbursed;
     }
-    
+
     /** @dev Execute a ruling of a dispute. It reimburse the fee to the winning party.
      *  This need to be extended by contract inheriting from it.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -57,10 +57,9 @@ import "./TwoPartyArbitrable.sol";
             partyA.send(amount);
         else if (_ruling==PARTY_B_WINS)
             partyB.send(amount);
-            
+
         amount=0;
     }
-    
-    
+
+
  }
- 

--- a/contracts/standard/arbitration/ArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/ArbitrableTransaction.sol
@@ -32,7 +32,7 @@ import "./TwoPartyArbitrable.sol";
 
     /** @dev Pay the party B. To be called when the good is delivered or the service rendered.
      */
-    function pay() onlyPartyA {
+    function pay() public onlyPartyA {
         partyB.transfer(amount);
         amount=0;
     }
@@ -40,7 +40,7 @@ import "./TwoPartyArbitrable.sol";
     /** @dev Reimburse party A. To be called if the good or service can't be fully provided.
      *  @param _amountReimbursed Amount to reimburse in wei.
      */
-    function reimburse(uint _amountReimbursed) onlyPartyB {
+    function reimburse(uint _amountReimbursed) public onlyPartyB {
         require(_amountReimbursed<=amount);
         partyA.transfer(_amountReimbursed);
         amount-=_amountReimbursed;

--- a/contracts/standard/arbitration/Arbitrator.sol
+++ b/contracts/standard/arbitration/Arbitrator.sol
@@ -58,7 +58,7 @@ contract Arbitrator{
      *  @param _extraData Can be used to give extra info on the appeal.
      */
     function appeal(uint _disputeID, bytes _extraData) public requireAppealFee(_disputeID,_extraData) payable {
-        AppealDecision(_disputeID, Arbitrable(msg.sender));
+        emit AppealDecision(_disputeID, Arbitrable(msg.sender));
     }
 
     /** @dev Compute the cost of appeal. It is recommended not to increase it often, as it can be higly time and gas consuming for the arbitrated contracts to cope with fee augmentation.

--- a/contracts/standard/arbitration/Arbitrator.sol
+++ b/contracts/standard/arbitration/Arbitrator.sol
@@ -16,29 +16,29 @@ import "./Arbitrable.sol";
  *  -Allow giving rulings. For this a function must call arbitrable.rule(disputeID,ruling).
  */
 contract Arbitrator{
-    
+
     enum DisputeStatus {Waiting, Appealable, Solved}
-    
+
     modifier requireArbitrationFee(bytes _extraData) {require(msg.value>=arbitrationCost(_extraData)); _;}
     modifier requireAppealFee(uint _disputeID, bytes _extraData) {require(msg.value>=appealCost(_disputeID, _extraData)); _;}
-    
+
     /** @dev To be raised when a dispute can be appealed.
      *  @param _disputeID ID of the dispute.
      */
     event AppealPossible(uint _disputeID);
-    
+
     /** @dev To be raised when a dispute is created.
      *  @param _disputeID ID of the dispute.
      *  @param _arbitrable The contract which created the dispute.
      */
     event DisputeCreation(uint indexed _disputeID, Arbitrable _arbitrable);
-    
+
     /** @dev To be raised when the current ruling is appealed.
      *  @param _disputeID ID of the dispute.
      *  @param _arbitrable The contract which created the dispute.
      */
     event AppealDecision(uint indexed _disputeID, Arbitrable _arbitrable);
-    
+
     /** @dev Create a dispute. Must be called by the arbitrable contract.
      *  Must be paid at least arbitrationCost(_extraData).
      *  @param _choices Amount of choices the arbitrator can make in this dispute.
@@ -46,13 +46,13 @@ contract Arbitrator{
      *  @return disputeID ID of the dispute created.
      */
     function createDispute(uint _choices, bytes _extraData) public requireArbitrationFee(_extraData) payable returns(uint disputeID)  {}
-    
+
     /** @dev Compute the cost of arbitration. It is recommended not to increase it often, as it can be highly time and gas consuming for the arbitrated contracts to cope with fee augmentation.
      *  @param _extraData Can be used to give additional info on the dispute to be created.
      *  @return fee Amount to be paid.
      */
     function arbitrationCost(bytes _extraData) public constant returns(uint fee);
-    
+
     /** @dev Appeal a ruling. Note that it has to be called before the arbitrator contract calls rule.
      *  @param _disputeID ID of the dispute to be appealed.
      *  @param _extraData Can be used to give extra info on the appeal.
@@ -60,24 +60,24 @@ contract Arbitrator{
     function appeal(uint _disputeID, bytes _extraData) public requireAppealFee(_disputeID,_extraData) payable {
         AppealDecision(_disputeID, Arbitrable(msg.sender));
     }
-    
+
     /** @dev Compute the cost of appeal. It is recommended not to increase it often, as it can be higly time and gas consuming for the arbitrated contracts to cope with fee augmentation.
      *  @param _disputeID ID of the dispute to be appealed.
      *  @param _extraData Can be used to give additional info on the dispute to be created.
      *  @return fee Amount to be paid.
      */
     function appealCost(uint _disputeID, bytes _extraData) public constant returns(uint fee);
-    
+
     /** @dev Return the status of a dispute.
      *  @param _disputeID ID of the dispute to rule.
      *  @return status The status of the dispute.
      */
     function disputeStatus(uint _disputeID) public constant returns(DisputeStatus status);
-    
+
     /** @dev Return the current ruling of a dispute. This is useful for parties to know if they should appeal.
      *  @param _disputeID ID of the dispute.
      *  @return ruling The current ruling which will be given if there is no appeal or which has been given.
      */
     function currentRuling(uint _disputeID) public constant returns(uint ruling);
-     
+
 }

--- a/contracts/standard/arbitration/ArbitratorCourt.sol
+++ b/contracts/standard/arbitration/ArbitratorCourt.sol
@@ -70,7 +70,7 @@ contract ArbitratorCourt is Arbitrator {
      *  @param _parentName The name of the `parent`.
      *  @param _parentAddress The address of the `parent`.
      */
-    function ArbitratorCourt(uint256 _maxLocalAppeals, string _parentName, Arbitrator _parentAddress) public {
+    constructor(uint256 _maxLocalAppeals, string _parentName, Arbitrator _parentAddress) public {
         maxLocalAppeals = _maxLocalAppeals;
         parent = Court({ name: _parentName, _address: _parentAddress });
     }

--- a/contracts/standard/arbitration/BackupedArbitrator.sol
+++ b/contracts/standard/arbitration/BackupedArbitrator.sol
@@ -1,1 +1,2 @@
 // TODO: Create a class where the arbitrator can be appealed if he is unresponsive or "rule 0" (refuse to give a ruling).
+pragma solidity ^0.4.24;

--- a/contracts/standard/arbitration/BountyVault.sol
+++ b/contracts/standard/arbitration/BountyVault.sol
@@ -4,3 +4,4 @@
 // Contributors can make claims to get points (and put a deposit). This leads to disputes with the team.
 // People can challenge points of contributors (and put a deposit). If they win their challenges, points are removed.
 // At the end of the month (and of the disputes, if there is any), the bounty is split between contributors in proportion of their points.
+pragma solidity ^0.4.24;

--- a/contracts/standard/arbitration/CentralizedArbitrator.sol
+++ b/contracts/standard/arbitration/CentralizedArbitrator.sol
@@ -13,7 +13,7 @@ import "./Arbitrator.sol";
  *  No appeals are possible.
  */
 contract CentralizedArbitrator is Arbitrator {
-    
+
     address public owner=msg.sender;
     uint arbitrationPrice; // Not public because arbitrationCost already acts as an accessor.
     uint constant NOT_PAYABLE_VALUE = (2**256-2)/2; // High value to be sure that the appeal is too expensive.
@@ -25,25 +25,25 @@ contract CentralizedArbitrator is Arbitrator {
         uint ruling;
         DisputeStatus status;
     }
-    
+
     modifier onlyOwner {require(msg.sender==owner); _;}
-    
+
     Dispute[] public disputes;
-    
+
     /** @dev Constructor. Set the initial arbitration price.
      *  @param _arbitrationPrice Amount to be paid for arbitration.
      */
-    function CentralizedArbitrator(uint _arbitrationPrice) public {
+    constructor(uint _arbitrationPrice) public {
         arbitrationPrice = _arbitrationPrice;
     }
-    
+
     /** @dev Set the arbitration price. Only callable by the owner.
      *  @param _arbitrationPrice Amount to be paid for arbitration.
      */
     function setArbitrationPrice(uint _arbitrationPrice) public onlyOwner {
         arbitrationPrice = _arbitrationPrice;
     }
-    
+
     /** @dev Cost of arbitration. Accessor to arbitrationPrice.
      *  @param _extraData Not used by this contract.
      *  @return fee Amount to be paid.
@@ -51,7 +51,7 @@ contract CentralizedArbitrator is Arbitrator {
     function arbitrationCost(bytes _extraData) public constant returns(uint fee) {
         return arbitrationPrice;
     }
-    
+
     /** @dev Cost of appeal. Since it is not possible, it's a high value which can never be paid.
      *  @param _disputeID ID of the dispute to be appealed. Not used by this contract.
      *  @param _extraData Not used by this contract.
@@ -60,7 +60,7 @@ contract CentralizedArbitrator is Arbitrator {
     function appealCost(uint _disputeID, bytes _extraData) public constant returns(uint fee) {
         return NOT_PAYABLE_VALUE;
     }
-    
+
     /** @dev Create a dispute. Must be called by the arbitrable contract.
      *  Must be paid at least arbitrationCost().
      *  @param _choices Amount of choices the arbitrator can make in this dispute. When ruling ruling<=choices.
@@ -79,7 +79,7 @@ contract CentralizedArbitrator is Arbitrator {
 		DisputeCreation(disputeID, Arbitrable(msg.sender));
 		return disputeID;
     }
-    
+
     /** @dev Give a ruling. UNTRUSTED.
      *  @param _disputeID ID of the dispute to rule.
      *  @param _ruling Ruling given by the arbitrator. Note that 0 means "Not able/wanting to make a decision".
@@ -87,18 +87,18 @@ contract CentralizedArbitrator is Arbitrator {
     function giveRuling(uint _disputeID, uint _ruling) public onlyOwner {
         Dispute dispute = disputes[_disputeID];
         require(_ruling<=dispute.choices);
-        
+
         uint fee = dispute.fee;
         Arbitrable arbitrated = dispute.arbitrated;
         dispute.arbitrated=Arbitrable(0x0); // Clean up to get gas back and prevent calling it again.
         dispute.fee=0;
         dispute.ruling=_ruling;
         dispute.status=DisputeStatus.Solved;
-        
+
         msg.sender.transfer(fee);
         arbitrated.rule(_disputeID,_ruling);
     }
-    
+
     /** @dev Return the status of a dispute.
      *  @param _disputeID ID of the dispute to rule.
      *  @return status The status of the dispute.
@@ -106,7 +106,7 @@ contract CentralizedArbitrator is Arbitrator {
     function disputeStatus(uint _disputeID) public constant returns(DisputeStatus status) {
         return disputes[_disputeID].status;
     }
-    
+
     /** @dev Return the ruling of a dispute.
      *  @param _disputeID ID of the dispute to rule.
      *  @return ruling The ruling which would or has been given.
@@ -115,4 +115,3 @@ contract CentralizedArbitrator is Arbitrator {
         return disputes[_disputeID].ruling;
     }
 }
-

--- a/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
@@ -15,16 +15,16 @@ import "./Arbitrator.sol";
  contract MultipleArbitrableTransaction {
     string constant RULING_OPTIONS = "Reimburse buyer;Pay seller";
 
-    
-    
+
+
     uint8 constant AMOUNT_OF_CHOICES = 2;
     uint8 constant BUYER_WINS = 1;
     uint8 constant SELLER_WINS = 2;
-    
+
     enum Party {Seller, Buyer}
-    
+
     enum Status {NoDispute, WaitingSeller, WaitingBuyer, DisputeCreated, Resolved}
-    
+
     struct Transaction {
         address seller;
         address buyer;
@@ -44,10 +44,10 @@ import "./Arbitrator.sol";
     mapping (bytes32 => uint) public disputeTxMap;
 
 
-    
+
     /** @dev Constructor.
      */
-    function MultipleArbitrableTransaction() public {
+    constructor() public {
     }
 
     /** @dev To be raised when a dispute is created. The main purpose of this event is to let the arbitrator know the meaning ruling IDs.
@@ -65,7 +65,7 @@ import "./Arbitrator.sol";
      *  @param _ruling The ruling which was given.
      */
     event Ruling(uint indexed _transactionId, Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
-    
+
     /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due to gas considerations).
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -73,20 +73,20 @@ import "./Arbitrator.sol";
      *  @param _evidence A link to evidence or if it is short the evidence itself. Can be web link ("http://X"), IPFS ("ipfs:/X") or another storing service (using the URI, see https://en.wikipedia.org/wiki/Uniform_Resource_Identifier ). One usecase of short evidence is to include the hash of the plain English contract.
      */
     event Evidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, address _party, string _evidence);
-    
+
     /** @dev To be emmited at contract creation. Contains the hash of the plain text contract. This will allow any party to show what was the original contract.
      *  This event is used as cheap way of storing it.
      *  @param _transactionId The index of the transaction.
      *  @param _contractHash Keccak256 hash of the plain text contract.
      */
     event ContractHash(uint indexed _transactionId, bytes32 _contractHash);
-    
+
     /** @dev Indicate that a party has to pay a fee or would otherwise be considered as loosing.
      *  @param _transactionId The index of the transaction.
      *  @param _party The party who has to pay.
      */
     event HasToPayFee(uint indexed _transactionId, Party _party);
-    
+
     /** @dev Give a ruling for a dispute. Must be called by the arbitrator.
      *  The purpose of this function is to ensure that the address calling it has the right to rule on the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -98,7 +98,7 @@ import "./Arbitrator.sol";
         require(msg.sender==address(transaction.arbitrator));
 
         emit Ruling(transactionId, Arbitrator(msg.sender),_disputeID,_ruling);
-        
+
         executeRuling(_disputeID,_ruling);
     }
 
@@ -116,7 +116,7 @@ import "./Arbitrator.sol";
         transaction.sellerFee += msg.value;
         require(transaction.sellerFee >= arbitrationCost); // Require that the total pay at least the arbitration cost.
         require(transaction.status < Status.DisputeCreated); // Make sure a dispute has not been created yet.
-        
+
         transaction.lastInteraction = now;
         if (transaction.buyerFee < arbitrationCost) { // The partyB still has to pay. This can also happens if he has paid, but arbitrationCost has increased.
             transaction.status = Status.WaitingBuyer;
@@ -125,7 +125,7 @@ import "./Arbitrator.sol";
             raiseDispute(_transactionId, arbitrationCost);
         }
     }
-    
+
     /** @dev Pay the arbitration fee to raise a dispute. To be called by the buyer. UNTRUSTED.
      *  Note that this function mirror payArbitrationFeeBySeller.
      *  @param _transactionId The index of the transaction.
@@ -138,7 +138,7 @@ import "./Arbitrator.sol";
         transaction.buyerFee += msg.value;
         require(transaction.buyerFee >= arbitrationCost); // Require that the total pay at least the arbitration cost.
         require(transaction.status < Status.DisputeCreated); // Make sure a dispute has not been created yet.
-        
+
         transaction.lastInteraction = now;
         if (transaction.sellerFee < arbitrationCost) { // The partyA still has to pay. This can also happens if he has paid, but arbitrationCost has increased.
             transaction.status = Status.WaitingSeller;
@@ -147,7 +147,7 @@ import "./Arbitrator.sol";
             raiseDispute(_transactionId, arbitrationCost);
         }
     }
-    
+
     /** @dev Create a dispute. UNTRUSTED.
      *  @param _transactionId The index of the transaction.
      *  @param _arbitrationCost Amount to pay the arbitrator.
@@ -159,7 +159,7 @@ import "./Arbitrator.sol";
         disputeTxMap[keccak256(transaction.arbitrator, transaction.disputeId)] = _transactionId;
         emit Dispute(_transactionId, transaction.arbitrator, transaction.disputeId,RULING_OPTIONS);
     }
-    
+
     /** @dev Reimburse partyA if partyB fails to pay the fee.
      *  @param _transactionId The index of the transaction.
      */
@@ -170,10 +170,10 @@ import "./Arbitrator.sol";
 
         require(transaction.status==Status.WaitingBuyer);
         require(now>=transaction.lastInteraction+transaction.timeout);
-        
+
         executeRuling(transaction.disputeId, SELLER_WINS);
     }
-    
+
     /** @dev Pay partyB if partyA fails to pay the fee.
      *  @param _transactionId The index of the transaction.
      */
@@ -184,10 +184,10 @@ import "./Arbitrator.sol";
 
         require(transaction.status == Status.WaitingSeller);
         require(now>=transaction.lastInteraction+transaction.timeout);
-        
+
         executeRuling(transaction.disputeId,BUYER_WINS);
     }
-    
+
     /** @dev Submit a reference to evidence. EVENT.
      *  @param _transactionId The index of the transaction.
      *  @param _evidence A link to an evidence using its URI.
@@ -195,11 +195,11 @@ import "./Arbitrator.sol";
     function submitEvidence(uint _transactionId, string _evidence) {
         Transaction storage transaction = transactions[_transactionId];
         require(msg.sender == transaction.buyer || msg.sender == transaction.seller);
-        
+
         require(transaction.status>=Status.DisputeCreated);
         emit Evidence(transaction.arbitrator,transaction.disputeId,msg.sender,_evidence);
     }
-    
+
     /** @dev Appeal an appealable ruling.
      *  Transfer the funds to the arbitrator.
      *  Note that no checks are required as the checks are done by the arbitrator.
@@ -209,10 +209,10 @@ import "./Arbitrator.sol";
     function appeal(uint _transactionId, bytes _extraData) payable public {
         Transaction storage transaction = transactions[_transactionId];
         require(msg.sender == transaction.buyer || msg.sender == transaction.seller);
-        
+
         transaction.arbitrator.appeal.value(msg.value)(transaction.disputeId,_extraData);
     }
-    
+
 
 
     /** @dev
@@ -223,7 +223,7 @@ import "./Arbitrator.sol";
      *  @param _arbitratorExtraData Extra data for the arbitrator.
      */
     function createTransaction(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _seller, bytes _arbitratorExtraData) payable public returns (uint transactionIndex) {
-        transactions.push(Transaction({ 
+        transactions.push(Transaction({
             seller: _seller,
             buyer: msg.sender,
             amount: msg.value,
@@ -253,9 +253,9 @@ import "./Arbitrator.sol";
         transaction.seller.send(transaction.amount);
         transaction.amount = 0;
 
-        transaction.status = Status.Resolved;    
+        transaction.status = Status.Resolved;
     }
-    
+
     /** @dev Reimburse party A. To be called if the good or service can't be fully provided.
      *  @param _transactionId The index of the transaction.
      *  @param _amountReimbursed Amount to reimburse in wei.
@@ -264,11 +264,11 @@ import "./Arbitrator.sol";
         Transaction storage transaction = transactions[_transactionId];
         require(transaction.seller == msg.sender);
         require(_amountReimbursed <= transaction.amount);
-        
+
         transaction.buyer.transfer(_amountReimbursed);
         transaction.amount -= _amountReimbursed;
     }
-    
+
     /** @dev Execute a ruling of a dispute. It reimburse the fee to the winning party.
      *  This need to be extended by contract inheriting from it.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -277,10 +277,10 @@ import "./Arbitrator.sol";
     function executeRuling(uint _disputeID, uint _ruling) internal {
         uint transactionId = disputeTxMap[keccak256(msg.sender,_disputeID)];
         Transaction storage transaction = transactions[transactionId];
-        
+
         require(_disputeID == transaction.disputeId);
         require(_ruling <= AMOUNT_OF_CHOICES);
-        
+
         // Give the arbitration fee back.
         // Note that we use send to prevent a party from blocking the execution.
         if (_ruling == SELLER_WINS) {

--- a/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
@@ -107,7 +107,7 @@ import "./Arbitrator.sol";
      *  This is not a vulnerability as the arbitrator can rule in favor of one party anyway.
      *  @param _transactionId The index of the transaction.
      */
-    function payArbitrationFeeBySeller(uint _transactionId) payable {
+    function payArbitrationFeeBySeller(uint _transactionId) public payable {
         Transaction storage transaction = transactions[_transactionId];
         require(msg.sender == transaction.seller);
 
@@ -130,7 +130,7 @@ import "./Arbitrator.sol";
      *  Note that this function mirror payArbitrationFeeBySeller.
      *  @param _transactionId The index of the transaction.
      */
-    function payArbitrationFeeByBuyer(uint _transactionId) payable {
+    function payArbitrationFeeByBuyer(uint _transactionId) public payable {
         Transaction storage transaction = transactions[_transactionId];
         require(msg.sender == transaction.buyer);
 
@@ -163,7 +163,7 @@ import "./Arbitrator.sol";
     /** @dev Reimburse partyA if partyB fails to pay the fee.
      *  @param _transactionId The index of the transaction.
      */
-    function timeOutBySeller(uint _transactionId) {
+    function timeOutBySeller(uint _transactionId) public {
         Transaction storage transaction = transactions[_transactionId];
         require(msg.sender == transaction.seller);
 
@@ -177,7 +177,7 @@ import "./Arbitrator.sol";
     /** @dev Pay partyB if partyA fails to pay the fee.
      *  @param _transactionId The index of the transaction.
      */
-    function timeOutByBuyer(uint _transactionId) {
+    function timeOutByBuyer(uint _transactionId) public {
         Transaction storage transaction = transactions[_transactionId];
         require(msg.sender == transaction.buyer);
 
@@ -192,7 +192,7 @@ import "./Arbitrator.sol";
      *  @param _transactionId The index of the transaction.
      *  @param _evidence A link to an evidence using its URI.
      */
-    function submitEvidence(uint _transactionId, string _evidence) {
+    function submitEvidence(uint _transactionId, string _evidence) public {
         Transaction storage transaction = transactions[_transactionId];
         require(msg.sender == transaction.buyer || msg.sender == transaction.seller);
 

--- a/contracts/standard/arbitration/Rental.sol
+++ b/contracts/standard/arbitration/Rental.sol
@@ -12,16 +12,16 @@ import "./TwoPartyArbitrable.sol";
  *  This is a a contract for rental agreement.
  *  This can be used to rent objects or properties.
  *  Party A is the renter. Party B is the owner.
- *  Party A put a deposit. If everything goes well, it will be given back. 
+ *  Party A put a deposit. If everything goes well, it will be given back.
  *  Otherwize parties can claim an amount of damages. If they disagree, the arbitrator will have to solve this dispute.
  */
  contract Rental is TwoPartyArbitrable {
     string constant RULING_OPTIONS = "Rule for party A (renter);Rule for Party B (owner)";
-    
+
     uint public amount; // Amount sent by party A.
     uint public damagesClaimedByPartyA; // The amount party A agrees to pay to compensate damages.
     uint public damagesClaimedByPartyB; // The amount party B claims to compensate damages.
-    
+
     /** @dev Constructor. Choose the arbitrator. Should be called by party A (the payer).
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _hashContract Keccak hash of the plain English contract.
@@ -29,7 +29,7 @@ import "./TwoPartyArbitrable.sol";
      *  @param _partyB The owner.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
      */
-    function Rental(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData) public TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData) payable {
+    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData) public TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData) payable {
         amount+=msg.value;
     }
 
@@ -42,12 +42,12 @@ import "./TwoPartyArbitrable.sol";
         require(status<Status.DisputeCreated); // Make sure that parties can't change when a dispute already started.
         require(_damages!=0); // Needed to avoid claiming 0 first and triggering an agreement. Use forfeitDeposit and unlockDeposit for the cases where 0 is claimed.
         require(_damages<=amount); // Make sure not to claim more than the contract has.
-        
+
         if (msg.sender==partyA)
             damagesClaimedByPartyA=_damages;
         else
             damagesClaimedByPartyB=_damages;
-            
+
         if (damagesClaimedByPartyA==damagesClaimedByPartyB) { // If there is an agreement.
             partyA.send((amount-damagesClaimedByPartyB)+partyAFee);
             partyB.send(damagesClaimedByPartyB+partyBFee);
@@ -59,9 +59,9 @@ import "./TwoPartyArbitrable.sol";
             status=Status.Resolved;
         }
     }
-    
 
-    
+
+
 
     /** @dev Forfeit the deposit to party B.
      *  To be called if the good has been completely broken or that the property damages exceed the deposit.
@@ -70,14 +70,14 @@ import "./TwoPartyArbitrable.sol";
         partyB.transfer(amount);
         amount=0;
     }
-    
+
     /** @dev Unlock party A deposit. To be called if the good or property has been returned without damages.
      */
     function unlockDeposit() public onlyPartyB {
         partyA.transfer(amount);
         amount=0;
     }
-    
+
     /** @dev Execute a ruling of a dispute. It reimburse the fee to the winning party.
      *  This need to be extended by contract inheriting from it.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -93,12 +93,11 @@ import "./TwoPartyArbitrable.sol";
             partyA.send(amount-damagesClaimedByPartyB);
             partyB.send(damagesClaimedByPartyB);
         }
-        
+
         amount=0;
         damagesClaimedByPartyA=0;
         damagesClaimedByPartyB=0;
     }
-    
-    
+
+
  }
- 

--- a/contracts/standard/arbitration/TwoPartyArbitrable.sol
+++ b/contracts/standard/arbitration/TwoPartyArbitrable.sol
@@ -25,23 +25,23 @@ contract TwoPartyArbitrable is Arbitrable {
     uint public disputeID;
     enum Status {NoDispute, WaitingPartyA, WaitingPartyB, DisputeCreated, Resolved}
     Status public status;
-    
+
     uint8 constant AMOUNT_OF_CHOICES = 2;
     uint8 constant PARTY_A_WINS = 1;
     uint8 constant PARTY_B_WINS = 2;
     string constant RULING_OPTIONS = "Party A wins;Party B wins"; // A plain English of what rulings do. Need to be redefined by the child class.
-    
+
     modifier onlyPartyA{ require(msg.sender==partyA); _; }
     modifier onlyPartyB{ require(msg.sender==partyB); _; }
     modifier onlyParty{ require(msg.sender==partyA || msg.sender==partyB); _; }
-    
+
     enum Party {PartyA, PartyB}
-    
+
     /** @dev Indicate that a party has to pay a fee or would otherwise be considered as loosing.
      *  @param _party The party who has to pay.
      */
     event HasToPayFee(Party _party);
-    
+
     /** @dev Constructor. Choose the arbitrator.
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _hashContract Keccak hash of the plain English contract.
@@ -49,13 +49,13 @@ contract TwoPartyArbitrable is Arbitrable {
      *  @param _partyB The recipient of the transaction.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
      */
-    function TwoPartyArbitrable(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData) Arbitrable(_arbitrator,_arbitratorExtraData,_hashContract) {
+    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData) Arbitrable(_arbitrator,_arbitratorExtraData,_hashContract) {
         timeout=_timeout;
         partyA=msg.sender;
         partyB=_partyB;
     }
-    
-    
+
+
     /** @dev Pay the arbitration fee to raise a dispute. To be called by the party A. UNTRUSTED.
      *  Note that the arbitrator can have createDispute throw, which will make this function throw and therefore lead to a party being timed-out.
      *  This is not a vulnerability as the arbitrator can rule in favor of one party anyway.
@@ -65,7 +65,7 @@ contract TwoPartyArbitrable is Arbitrable {
         partyAFee+=msg.value;
         require(partyAFee >= arbitrationCost); // Require that the total pay at least the arbitration cost.
         require(status<Status.DisputeCreated); // Make sure a dispute has not been created yet.
-        
+
         lastInteraction=now;
         if (partyBFee < arbitrationCost) { // The partyB still has to pay. This can also happens if he has paid, but arbitrationCost has increased.
             status=Status.WaitingPartyB;
@@ -74,8 +74,8 @@ contract TwoPartyArbitrable is Arbitrable {
             raiseDispute(arbitrationCost);
         }
     }
-    
-    
+
+
     /** @dev Pay the arbitration fee to raise a dispute. To be called by the party B. UNTRUSTED.
      *  Note that this function mirror payArbitrationFeeByPartyA.
      */
@@ -84,7 +84,7 @@ contract TwoPartyArbitrable is Arbitrable {
         partyBFee+=msg.value;
         require(partyBFee >= arbitrationCost); // Require that the total pay at least the arbitration cost.
         require(status<Status.DisputeCreated); // Make sure a dispute has not been created yet.
-        
+
         lastInteraction=now;
         if (partyAFee < arbitrationCost) { // The partyA still has to pay. This can also happens if he has paid, but arbitrationCost has increased.
             status=Status.WaitingPartyA;
@@ -93,7 +93,7 @@ contract TwoPartyArbitrable is Arbitrable {
             raiseDispute(arbitrationCost);
         }
     }
-    
+
     /** @dev Create a dispute. UNTRUSTED.
      *  @param _arbitrationCost Amount to pay the arbitrator.
      */
@@ -102,25 +102,25 @@ contract TwoPartyArbitrable is Arbitrable {
         disputeID=arbitrator.createDispute.value(_arbitrationCost)(AMOUNT_OF_CHOICES,arbitratorExtraData);
         Dispute(arbitrator,disputeID,RULING_OPTIONS);
     }
-    
+
     /** @dev Reimburse partyA if partyB fails to pay the fee.
      */
     function timeOutByPartyA() onlyPartyA {
         require(status==Status.WaitingPartyB);
         require(now>=lastInteraction+timeout);
-        
+
         executeRuling(disputeID,PARTY_A_WINS);
     }
-    
+
     /** @dev Pay partyB if partyA fails to pay the fee.
      */
     function timeOutByPartyB() onlyPartyB {
         require(status==Status.WaitingPartyA);
         require(now>=lastInteraction+timeout);
-        
+
         executeRuling(disputeID,PARTY_B_WINS);
     }
-    
+
     /** @dev Submit a reference to evidence. EVENT.
      *  @param _evidence A link to an evidence using its URI.
      */
@@ -128,7 +128,7 @@ contract TwoPartyArbitrable is Arbitrable {
         require(status>=Status.DisputeCreated);
         Evidence(arbitrator,disputeID,msg.sender,_evidence);
     }
-    
+
     /** @dev Appeal an appealable ruling.
      *  Transfer the funds to the arbitrator.
      *  Note that no checks are required as the checks are done by the arbitrator.
@@ -137,7 +137,7 @@ contract TwoPartyArbitrable is Arbitrable {
     function appeal(bytes _extraData) onlyParty payable {
         arbitrator.appeal.value(msg.value)(disputeID,_extraData);
     }
-    
+
     /** @dev Execute a ruling of a dispute. It reimburse the fee to the winning party.
      *  This need to be extended by contract inheriting from it.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -146,7 +146,7 @@ contract TwoPartyArbitrable is Arbitrable {
     function executeRuling(uint _disputeID, uint _ruling) internal {
         require(_disputeID==disputeID);
         require(_ruling<=AMOUNT_OF_CHOICES);
-        
+
         // Give the arbitration fee back.
         // Note that we use send to prevent a party from blocking the execution.
         if (_ruling==PARTY_A_WINS)
@@ -155,5 +155,5 @@ contract TwoPartyArbitrable is Arbitrable {
             partyB.send(partyAFee > partyBFee ? partyAFee : partyBFee);
         status=Status.Resolved;
     }
-    
+
 }

--- a/contracts/standard/arbitration/TwoPartyArbitrable.sol
+++ b/contracts/standard/arbitration/TwoPartyArbitrable.sol
@@ -60,7 +60,7 @@ contract TwoPartyArbitrable is Arbitrable {
      *  Note that the arbitrator can have createDispute throw, which will make this function throw and therefore lead to a party being timed-out.
      *  This is not a vulnerability as the arbitrator can rule in favor of one party anyway.
      */
-    function payArbitrationFeeByPartyA() payable onlyPartyA {
+    function payArbitrationFeeByPartyA() public payable onlyPartyA {
         uint arbitrationCost=arbitrator.arbitrationCost(arbitratorExtraData);
         partyAFee+=msg.value;
         require(partyAFee >= arbitrationCost); // Require that the total pay at least the arbitration cost.
@@ -79,7 +79,7 @@ contract TwoPartyArbitrable is Arbitrable {
     /** @dev Pay the arbitration fee to raise a dispute. To be called by the party B. UNTRUSTED.
      *  Note that this function mirror payArbitrationFeeByPartyA.
      */
-    function payArbitrationFeeByPartyB() payable onlyPartyB {
+    function payArbitrationFeeByPartyB() public payable onlyPartyB {
         uint arbitrationCost=arbitrator.arbitrationCost(arbitratorExtraData);
         partyBFee+=msg.value;
         require(partyBFee >= arbitrationCost); // Require that the total pay at least the arbitration cost.
@@ -105,7 +105,7 @@ contract TwoPartyArbitrable is Arbitrable {
 
     /** @dev Reimburse partyA if partyB fails to pay the fee.
      */
-    function timeOutByPartyA() onlyPartyA {
+    function timeOutByPartyA() public onlyPartyA {
         require(status==Status.WaitingPartyB);
         require(now>=lastInteraction+timeout);
 
@@ -114,7 +114,7 @@ contract TwoPartyArbitrable is Arbitrable {
 
     /** @dev Pay partyB if partyA fails to pay the fee.
      */
-    function timeOutByPartyB() onlyPartyB {
+    function timeOutByPartyB() public onlyPartyB {
         require(status==Status.WaitingPartyA);
         require(now>=lastInteraction+timeout);
 
@@ -124,7 +124,7 @@ contract TwoPartyArbitrable is Arbitrable {
     /** @dev Submit a reference to evidence. EVENT.
      *  @param _evidence A link to an evidence using its URI.
      */
-    function submitEvidence(string _evidence) onlyParty {
+    function submitEvidence(string _evidence) public onlyParty {
         require(status>=Status.DisputeCreated);
         Evidence(arbitrator,disputeID,msg.sender,_evidence);
     }
@@ -134,7 +134,7 @@ contract TwoPartyArbitrable is Arbitrable {
      *  Note that no checks are required as the checks are done by the arbitrator.
      *  @param _extraData Extra data for the arbitrator appeal procedure.
      */
-    function appeal(bytes _extraData) onlyParty payable {
+    function appeal(bytes _extraData) public onlyParty payable {
         arbitrator.appeal.value(msg.value)(disputeID,_extraData);
     }
 

--- a/contracts/standard/arbitration/TwoPartyArbitrable.sol
+++ b/contracts/standard/arbitration/TwoPartyArbitrable.sol
@@ -69,7 +69,7 @@ contract TwoPartyArbitrable is Arbitrable {
         lastInteraction=now;
         if (partyBFee < arbitrationCost) { // The partyB still has to pay. This can also happens if he has paid, but arbitrationCost has increased.
             status=Status.WaitingPartyB;
-            HasToPayFee(Party.PartyB);
+            emit HasToPayFee(Party.PartyB);
         } else { // The partyB has also paid the fee. We create the dispute
             raiseDispute(arbitrationCost);
         }
@@ -88,7 +88,7 @@ contract TwoPartyArbitrable is Arbitrable {
         lastInteraction=now;
         if (partyAFee < arbitrationCost) { // The partyA still has to pay. This can also happens if he has paid, but arbitrationCost has increased.
             status=Status.WaitingPartyA;
-            HasToPayFee(Party.PartyA);
+            emit HasToPayFee(Party.PartyA);
         } else { // The partyA has also paid the fee. We create the dispute
             raiseDispute(arbitrationCost);
         }

--- a/contracts/standard/permission/AddressPermissionList.sol
+++ b/contracts/standard/permission/AddressPermissionList.sol
@@ -22,10 +22,10 @@ contract AddressPermissionList is PermissionList {
      *  @dev Constructs the address permission list and sets the type.
      *  @param _blacklist True if the list should function as a blacklist, false if it should function as a whitelist.
      */
-    function AddressPermissionList(bool _blacklist) PermissionList(_blacklist) public {}
+    constructor(bool _blacklist) PermissionList(_blacklist) public {}
 
     /* Public Views */
-    
+
     /**
      *  @dev Return true if the address is allowed.
      *  @param _value The address we want to check.

--- a/contracts/standard/permission/ArbitrableBlacklist.sol
+++ b/contracts/standard/permission/ArbitrableBlacklist.sol
@@ -60,7 +60,7 @@ contract ArbitrableBlacklist is PermissionInterface, Arbitrable {
      *  @param _stake The amount in weis of deposit required for a submission or a challenge.
      *  @param _timeToChallenge The time in second, others parties have to challenge
      */
-    function ArbitrableBlacklist(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash, uint _stake, uint _timeToChallenge) Arbitrable(_arbitrator, _arbitratorExtraData, _contractHash) public {
+    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash, uint _stake, uint _timeToChallenge) Arbitrable(_arbitrator, _arbitratorExtraData, _contractHash) public {
         arbitrator=_arbitrator;
         arbitratorExtraData=_arbitratorExtraData;
         stake=_stake;

--- a/contracts/standard/permission/ArbitrablePermissionList.sol
+++ b/contracts/standard/permission/ArbitrablePermissionList.sol
@@ -86,7 +86,7 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
      *  @param _stake The amount in Weis of deposit required for a submission or a challenge.
      *  @param _timeToChallenge The time in seconds, other parties have to challenge.
      */
-    function ArbitrablePermissionList(
+    constructor(
         bytes32 _contractHash,
         bool _blacklist,
         bool _appendOnly,
@@ -336,7 +336,7 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
                 if (index == _count) break;
             }
         }
-        
+
         return values;
     }
 }

--- a/contracts/standard/permission/PermissionList.sol
+++ b/contracts/standard/permission/PermissionList.sol
@@ -10,11 +10,11 @@ import "./PermissionInterface.sol";
 
 /**
  *  @title Permission List
- *  This is a permission list for arbitrary values. The owner can add or remove values. 
+ *  This is a permission list for arbitrary values. The owner can add or remove values.
  */
 contract PermissionList is Ownable, PermissionInterface {
     /* Storage */
-    
+
     bool blacklist; // True if the list should function as a blacklist, false if it should function as a whitelist.
     mapping(bytes32 => bool) list; // True if the value is registered.
 
@@ -24,22 +24,22 @@ contract PermissionList is Ownable, PermissionInterface {
      *  @dev Constructs the permission list and sets the type.
      *  @param _blacklist True if the list should function as a blacklist, false if it should function as a whitelist.
      */
-    function PermissionList(bool _blacklist) public {
+    constructor(bool _blacklist) public {
         blacklist = _blacklist;
     }
 
     /* Public */
-    
+
     function add(bytes32 _value) public onlyOwner {
         list[_value] = true;
     }
-    
+
     function remove(bytes32 _value) public onlyOwner {
         list[_value] = false;
     }
 
     /* Public Views */
-    
+
     /**
      *  @dev Return true if the value is allowed.
      *  @param _value The value we want to check.

--- a/contracts/standard/proxy/ArbitratorVersioningProxy.sol
+++ b/contracts/standard/proxy/ArbitratorVersioningProxy.sol
@@ -28,7 +28,7 @@ contract ArbitratorVersioningProxy is Arbitrator, VersioningProxy {
      * @notice Constructs the arbitrator versioning proxy with the first arbitrator contract version address and tags it v0.0.1.
      * @param _firstAddress The address of the first arbitrator contract version.
      */
-    function ArbitratorVersioningProxy(Arbitrator _firstAddress) VersioningProxy("0.0.1", _firstAddress) public {}
+    constructor(Arbitrator _firstAddress) VersioningProxy("0.0.1", _firstAddress) public {}
 
     /* Public */
 
@@ -58,7 +58,7 @@ contract ArbitratorVersioningProxy is Arbitrator, VersioningProxy {
             uint256 _arbitratorDisputeID = Arbitrator(implementation).createDispute.value(msg.value)(_choices, _extraData);
             disputes[_disputeID] = Dispute({ arbitrator: Arbitrator(implementation), disputeID: _arbitratorDisputeID, choices: _choices });
         }
-        
+
         Arbitrator(implementation).appeal.value(msg.value)(disputes[_disputeID].disputeID, _extraData);
     }
 

--- a/contracts/standard/proxy/ExperimentalProxy.sol
+++ b/contracts/standard/proxy/ExperimentalProxy.sol
@@ -18,7 +18,7 @@ contract ExperimentalProxy {
      * @param _storageIsEternal Wether this contract should store all storage. I.e. Use 'delegatecall'.
      * @param _implementation The initial 'implementation' contract address.
      */
-    function ExperimentalProxy(bool _storageIsEternal, address _implementation) public {
+    constructor(bool _storageIsEternal, address _implementation) public {
         storageIsEternal = _storageIsEternal;
         implementation = _implementation;
     }
@@ -43,7 +43,7 @@ contract ExperimentalProxy {
         assembly {
             // Start of payload raw data (skip over size slot)
             let _dataPtr := add(_data, 0x20)
-            
+
             // Payload's size
             let _dataSize := mload(_data)
 
@@ -62,11 +62,11 @@ contract ExperimentalProxy {
 
             let _retPtr := mload(0x40) // Start of free memory
             let _retDataPtr := add(_retPtr, 0x20) // Make space for 'bytes' size
-    
+
             // Build `_retData` 'bytes'
             mstore(_retPtr, _retSize) // Copy size
             returndatacopy(_retDataPtr, 0, _retSize) // Copy returned data
-    
+
             // Figure out wether to revert or continue with the returned data
             switch _result
             case 0 { // Error

--- a/contracts/standard/proxy/VersioningProxy.sol
+++ b/contracts/standard/proxy/VersioningProxy.sol
@@ -118,7 +118,7 @@ contract VersioningProxy {
 
         // Call handler and fire event
         handleStableChange(prevTag, prevAddress, _nextTag, nextAddress); // on-chain
-        OnStableChange(prevTag, prevAddress, _nextTag, nextAddress); // off-chain
+        emit OnStableChange(prevTag, prevAddress, _nextTag, nextAddress); // off-chain
 
         // Change proxy target
         implementation = nextAddress;

--- a/contracts/standard/proxy/VersioningProxy.sol
+++ b/contracts/standard/proxy/VersioningProxy.sol
@@ -52,7 +52,7 @@ contract VersioningProxy {
      *  @param _firstTag The version tag of the first version of the managed contract.
      *  @param _firstAddress The address of the first verion of the managed contract.
      */
-    function VersioningProxy(bytes32 _firstTag, address _firstAddress) public {
+    constructor(bytes32 _firstTag, address _firstAddress) public {
         implementation = _firstAddress;
         publish(_firstTag, _firstAddress);
     }
@@ -112,7 +112,7 @@ contract VersioningProxy {
         // Save current tag and address for handlers
         bytes32 prevTag = stable.tag;
         address prevAddress = stable._address;
-    
+
         // Set 'stable'
         stable = Deployment({tag: _nextTag, _address: nextAddress});
 

--- a/contracts/standard/rng/BlockhashRNG.sol
+++ b/contracts/standard/rng/BlockhashRNG.sol
@@ -1,32 +1,32 @@
 /**
  *  @title Random Number Generator usign blockhash
  *  @author Clément Lesaege - <clement@lesaege.com>
- *  
+ *
  *  This contract implement the RNG standard and giving parties incentives in saving the blockhash to avoid it to become unreachable after 256 blocks.
- * 
+ *
  */
 pragma solidity ^0.4.15;
- 
+
 import "./RNG.sol";
 
 /** Simple Random Number Generator returning the blockhash.
- *  Allows saving the random number for use in the future. 
+ *  Allows saving the random number for use in the future.
  *  It allows the contract to still access the blockhash even after 256 blocks.
  *  The first party to call the save function gets the reward.
  */
 contract BlockHashRNG is RNG {
-    
+
     mapping (uint => uint) public randomNumber; // RN[block] is the random number for this block 0 otherwise.
     mapping (uint => uint) public reward; // reward[block] is the amount to be paid to the party w.
-    
 
-    
+
+
     /** @dev Contribute to the reward of a random number.
      *  @param _block Block the random number is linked to.
      */
     function contribute(uint _block) public payable { reward[_block]+=msg.value; }
-    
-    
+
+
     /** @dev Return the random number. If it has not been saved and is still computable compute it.
      *  @param _block Block the random number is linked to.
      *  @return RN Random Number. If the number is not ready or has not been requested 0 instead.
@@ -40,19 +40,19 @@ contract BlockHashRNG is RNG {
         else
             return RN;
     }
-    
+
     /** @dev Save the random number for this blockhash and give the reward to the caller.
      *  @param _block Block the random number is linked to.
      */
     function saveRN(uint _block) public {
-        if (block.blockhash(_block)!=0x0) {
-            uint rewardToSend=reward[_block];
-            reward[_block]=0;
-            randomNumber[_block]=uint(block.blockhash(_block));
-            
+        if (blockhash(_block) != 0x0) {
+            uint rewardToSend = reward[_block];
+            reward[_block] = 0;
+            randomNumber[_block] = uint(blockhash(_block));
+
             msg.sender.send(rewardToSend); // Note that the use of send is on purpose as we don't want to block in case the msg.sender has a fallback issue.
-            
-        }  
+
+        }
     }
-    
+
 }

--- a/contracts/standard/rng/BlockhashRNGFallback.sol
+++ b/contracts/standard/rng/BlockhashRNGFallback.sol
@@ -26,10 +26,10 @@ contract BlockHashRNGFallback is BlockHashRNG {
         if (_block<block.number) {
             uint rewardToSend=reward[_block];
             reward[_block]=0;
-            if (block.blockhash(_block)!=0x0) // Normal case.
-                randomNumber[_block]=uint(block.blockhash(_block));
+            if (blockhash(_block)!=0x0) // Normal case.
+                randomNumber[_block]=uint(blockhash(_block));
             else // The contract was not called in time. Fallback to returning previous blockhash.
-                randomNumber[_block]=uint(block.blockhash(block.number-1));
+                randomNumber[_block]=uint(blockhash(block.number-1));
             
             msg.sender.send(rewardToSend); // Note that the use of send is on purpose as we don't want to block in case the msg.sender has a fallback issue.
             

--- a/contracts/standard/rng/ConstantNG.sol
+++ b/contracts/standard/rng/ConstantNG.sol
@@ -15,7 +15,7 @@ pragma solidity ^0.4.15;
     /** @dev Constructor.
      *  @param _number The number to always return.
      */
-    function ConstantNG(uint _number) public {
+    constructor(uint _number) public {
         number = _number;
     }
 

--- a/contracts/standard/rng/RNG.sol
+++ b/contracts/standard/rng/RNG.sol
@@ -1,31 +1,31 @@
 /**
  *  @title Random Number Generator Standard
  *  @author Clément Lesaege - <clement@lesaege.com>
- *  
+ *
  */
- 
+
 pragma solidity ^0.4.15;
- 
+
  contract RNG{
-     
+
     /** @dev Contribute to the reward of a random number.
      *  @param _block Block the random number is linked to.
      */
-    function contribute(uint _block) payable;
-    
+    function contribute(uint _block) public payable;
+
     /** @dev Request a random number.
      *  @param _block Block linked to the request.
      */
-    function requestRN(uint _block) payable {
+    function requestRN(uint _block) public payable {
         contribute(_block);
     }
-    
+
     /** @dev Get the random number.
      *  @param _block Block the random number is linked to.
      *  @return RN Random Number. If the number is not ready or has not been required 0 instead.
      */
     function getRN(uint _block) public constant returns (uint RN);
-    
+
     /** @dev Get a uncorrelated random number. Act like getRN but give a different number for each sender.
      *  This is to avoid all users having the same number for a block which could pose issues.
      *  @param _block Block the random number is linked to.
@@ -38,11 +38,5 @@ pragma solidity ^0.4.15;
         else
             return uint(keccak256(msg.sender,baseRN));
     }
-    
+
  }
-
-
-
-
- 
- 


### PR DESCRIPTION
Fixes #57 

- [x] Fix constructor declarations to conform new constructor style guide
- [x] Specify compiler versions
- [x] Declare visibility modifiers explicitly 
- [x] Don't omit `emit` keyword when invoking events
- [x] Replace `block.blockhash()` with `blockhash()`