### PR TITLE
feat: add MetaEvidence events

### DIFF
--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -36,6 +36,18 @@ contract Arbitrable{
      */
     event Ruling(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
 
+    /** @dev To be emmited when meta-evidence is submitted.
+     *  @param _evidence A link to the meta-evidence JSON.
+     */
+    event MetaEvidence(string indexed _evidence);
+
+    /** @dev To be emmited when a dispute is created to link the correct meta-evidence to the disputeID
+     *  @param _arbitrator The arbitrator of the contract.
+     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _evidence A link to the meta-evidence JSON.
+     */
+    event LinkMetaEvidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, string _evidence);
+
     /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due tp gas considerations).
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.

--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -37,16 +37,17 @@ contract Arbitrable{
     event Ruling(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
 
     /** @dev To be emmited when meta-evidence is submitted.
+     *  @param _metaEvidenceID Unique identifier of meta-evidence.
      *  @param _evidence A link to the meta-evidence JSON.
      */
-    event MetaEvidence(string indexed _evidence);
+    event MetaEvidence(uint indexed _metaEvidenceID, string _evidence);
 
     /** @dev To be emmited when a dispute is created to link the correct meta-evidence to the disputeID
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _evidence A link to the meta-evidence JSON.
+     *  @param _metaEvidenceID Unique identifier of meta-evidence.
      */
-    event LinkMetaEvidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, string _evidence);
+    event LinkMetaEvidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID);
 
     /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due tp gas considerations).
      *  @param _arbitrator The arbitrator of the contract.

--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -57,20 +57,13 @@ contract Arbitrable{
      */
     event Evidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, address _party, string _evidence);
 
-    /** @dev To be emmited at contract creation. Contains the hash of the plain text contract. This will allow any party to show what was the original contract.
-     *  This event is used as cheap way of storing it.
-     *  @param _contractHash Keccak256 hash of the plain text contract.
-     */
-    event ContractHash(bytes32 _contractHash);
-
     /** @dev Constructor. Choose the arbitrator.
      *  @param _arbitrator The arbitrator of the contract.
-     *  @param _contractHash Keccak256 hash of the plain text contract.
+     *  @param _arbitratorExtraData Extra data for the arbitrator.
      */
-    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash) {
+    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData) public {
         arbitrator = _arbitrator;
         arbitratorExtraData = _arbitratorExtraData;
-        emit ContractHash(_contractHash);
     }
 
     /** @dev Give a ruling for a dispute. Must be called by the arbitrator.

--- a/contracts/standard/arbitration/ArbitrableDeposit.sol
+++ b/contracts/standard/arbitration/ArbitrableDeposit.sol
@@ -50,11 +50,10 @@ contract ArbitrableDeposit is Arbitrable {
 
     /** @dev Constructor. Choose the arbitrator
      *  @param _arbitrator The arbitrator of the contract.
-     *  @param _hashContract Keccak256 hash of the plain text contract.
      *  @param _timeout Time after which a party automatically loose a dispute.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
      */
-    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, bytes _arbitratorExtraData, uint _claimRate) Arbitrable(_arbitrator, _arbitratorExtraData, _hashContract) public payable {
+    constructor(Arbitrator _arbitrator, uint _timeout, bytes _arbitratorExtraData, uint _claimRate) Arbitrable(_arbitrator, _arbitratorExtraData) public payable {
         timeout = _timeout;
         claimRate = _claimRate;
         status = Status.NoDispute;

--- a/contracts/standard/arbitration/ArbitrableTokens/FundingVault.sol
+++ b/contracts/standard/arbitration/ArbitrableTokens/FundingVault.sol
@@ -51,7 +51,6 @@ contract FundingVault is Arbitrable {
 
     /** @dev Constructor. Choose the arbitrator.
      *  @param _arbitrator The arbitrator of the contract.
-     *  @param _contractHash Keccak256 hash of the plain text contract.
      *  @param _team The address of the team who will be able to claim milestone completion.
      *  @param _token The token whose holders are able to dispute milestone claims.
      *  @param _funder The party putting funds in the vault.
@@ -60,7 +59,7 @@ contract FundingVault is Arbitrable {
      *  @param _additionalTimeToWithdraw The time in seconds which is added per ‱ of tokens disputing the claim.
      *  @param _timeout Maximum time to pay arbitration fees after the other side did.
      */
-    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash, address _team, address _token, address _funder, uint _disputeThreshold, uint _claimToWithdrawTime, uint _additionalTimeToWithdraw, uint _timeout) public Arbitrable(_arbitrator,_arbitratorExtraData,_contractHash) {
+    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, address _team, address _token, address _funder, uint _disputeThreshold, uint _claimToWithdrawTime, uint _additionalTimeToWithdraw, uint _timeout) public Arbitrable(_arbitrator,_arbitratorExtraData) {
         team=_team;
         token=MiniMeToken(_token);
         funder=_funder;

--- a/contracts/standard/arbitration/ArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/ArbitrableTransaction.sol
@@ -21,13 +21,12 @@ import "./TwoPartyArbitrable.sol";
 
     /** @dev Constructor. Choose the arbitrator. Should be called by party A (the payer).
      *  @param _arbitrator The arbitrator of the contract.
-     *  @param _hashContract Keccak hash of the plain English contract.
      *  @param _timeout Time after which a party automatically loose a dispute.
      *  @param _partyB The recipient of the transaction.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
      *  @param _metaEvidence Link to meta-evidence JSON.
      */
-    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData, string _metaEvidence) TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData, _metaEvidence) payable {
+    constructor(Arbitrator _arbitrator, uint _timeout, address _partyB, bytes _arbitratorExtraData, string _metaEvidence) TwoPartyArbitrable(_arbitrator,_timeout,_partyB,_arbitratorExtraData, _metaEvidence) payable public {
         amount+=msg.value;
     }
 

--- a/contracts/standard/arbitration/ArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/ArbitrableTransaction.sol
@@ -25,8 +25,9 @@ import "./TwoPartyArbitrable.sol";
      *  @param _timeout Time after which a party automatically loose a dispute.
      *  @param _partyB The recipient of the transaction.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
+     *  @param _metaEvidence Link to meta-evidence JSON.
      */
-    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData) TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData) payable {
+    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData, string _metaEvidence) TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData, _metaEvidence) payable {
         amount+=msg.value;
     }
 

--- a/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
@@ -62,15 +62,15 @@ import "./Arbitrator.sol";
     event Ruling(uint indexed _transactionId, Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
 
     /** @dev To be emmited when meta-evidence is submitted.
-     *  @param _transactionId The index of the transaction
+     *  @param _transactionId The index of the transaction.
      *  @param _evidence A link to the meta-evidence JSON.
      */
     event MetaEvidence(uint indexed _transactionId, string _evidence);
 
-    /** @dev To be emmited when a dispute is created to link the correct meta-evidence to the disputeID
+    /** @dev To be emmited when a dispute is created to link the correct meta-evidence to the disputeID.
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _transactionId The index of the transaction
+     *  @param _transactionId The index of the transaction.
      */
     event LinkMetaEvidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _transactionId);
 

--- a/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
@@ -14,9 +14,6 @@ import "./Arbitrator.sol";
  */
  contract MultipleArbitrableTransaction {
     string constant RULING_OPTIONS = "Reimburse buyer;Pay seller";
-
-
-
     uint8 constant AMOUNT_OF_CHOICES = 2;
     uint8 constant BUYER_WINS = 1;
     uint8 constant SELLER_WINS = 2;
@@ -43,8 +40,6 @@ import "./Arbitrator.sol";
 
     mapping (bytes32 => uint) public disputeTxMap;
 
-
-
     /** @dev Constructor.
      */
     constructor() public {
@@ -66,6 +61,19 @@ import "./Arbitrator.sol";
      */
     event Ruling(uint indexed _transactionId, Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
 
+    /** @dev To be emmited when meta-evidence is submitted.
+     *  @param _transactionId The index of the transaction
+     *  @param _evidence A link to the meta-evidence JSON.
+     */
+    event MetaEvidence(uint indexed _transactionId, string _evidence);
+
+    /** @dev To be emmited when a dispute is created to link the correct meta-evidence to the disputeID
+     *  @param _arbitrator The arbitrator of the contract.
+     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _transactionId The index of the transaction
+     */
+    event LinkMetaEvidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _transactionId);
+
     /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due to gas considerations).
      *  @param _arbitrator The arbitrator of the contract.
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
@@ -73,13 +81,6 @@ import "./Arbitrator.sol";
      *  @param _evidence A link to evidence or if it is short the evidence itself. Can be web link ("http://X"), IPFS ("ipfs:/X") or another storing service (using the URI, see https://en.wikipedia.org/wiki/Uniform_Resource_Identifier ). One usecase of short evidence is to include the hash of the plain English contract.
      */
     event Evidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, address _party, string _evidence);
-
-    /** @dev To be emmited at contract creation. Contains the hash of the plain text contract. This will allow any party to show what was the original contract.
-     *  This event is used as cheap way of storing it.
-     *  @param _transactionId The index of the transaction.
-     *  @param _contractHash Keccak256 hash of the plain text contract.
-     */
-    event ContractHash(uint indexed _transactionId, bytes32 _contractHash);
 
     /** @dev Indicate that a party has to pay a fee or would otherwise be considered as loosing.
      *  @param _transactionId The index of the transaction.
@@ -158,6 +159,7 @@ import "./Arbitrator.sol";
         transaction.disputeId = transaction.arbitrator.createDispute.value(_arbitrationCost)(AMOUNT_OF_CHOICES,transaction.arbitratorExtraData);
         disputeTxMap[keccak256(transaction.arbitrator, transaction.disputeId)] = _transactionId;
         emit Dispute(_transactionId, transaction.arbitrator, transaction.disputeId,RULING_OPTIONS);
+        emit LinkMetaEvidence(transaction.arbitrator,transaction.disputeId,_transactionId);
     }
 
     /** @dev Reimburse partyA if partyB fails to pay the fee.
@@ -213,16 +215,14 @@ import "./Arbitrator.sol";
         transaction.arbitrator.appeal.value(msg.value)(transaction.disputeId,_extraData);
     }
 
-
-
     /** @dev
      *  @param _arbitrator The arbitrator of the contract.
-     *  @param _hashContract Keccak hash of the plain English contract.
      *  @param _timeout Time after which a party automatically loose a dispute.
      *  @param _seller The recipient of the transaction.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
+     *  @param _metaEvidence Link to the meta-evidence.
      */
-    function createTransaction(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _seller, bytes _arbitratorExtraData) payable public returns (uint transactionIndex) {
+    function createTransaction(Arbitrator _arbitrator, uint _timeout, address _seller, bytes _arbitratorExtraData, string _metaEvidence) payable public returns (uint transactionIndex) {
         transactions.push(Transaction({
             seller: _seller,
             buyer: msg.sender,
@@ -236,7 +236,7 @@ import "./Arbitrator.sol";
             lastInteraction: now,
             status: Status.NoDispute
         }));
-        emit ContractHash(transactions.length - 1, _hashContract);
+        emit MetaEvidence(transactions.length - 1, _metaEvidence);
         return transactions.length - 1;
     }
 

--- a/contracts/standard/arbitration/Rental.sol
+++ b/contracts/standard/arbitration/Rental.sol
@@ -24,13 +24,12 @@ import "./TwoPartyArbitrable.sol";
 
     /** @dev Constructor. Choose the arbitrator. Should be called by party A (the payer).
      *  @param _arbitrator The arbitrator of the contract.
-     *  @param _hashContract Keccak hash of the plain English contract.
      *  @param _timeout Time after which a party automatically loose a dispute.
      *  @param _partyB The owner.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
      *  @param _metaEvidence Link to meta-evidence JSON.
      */
-    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData, string _metaEvidence) public TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData, _metaEvidence) payable {
+    constructor(Arbitrator _arbitrator, uint _timeout, address _partyB, bytes _arbitratorExtraData, string _metaEvidence) public TwoPartyArbitrable(_arbitrator,_timeout,_partyB,_arbitratorExtraData, _metaEvidence) payable {
         amount+=msg.value;
     }
 

--- a/contracts/standard/arbitration/Rental.sol
+++ b/contracts/standard/arbitration/Rental.sol
@@ -28,8 +28,9 @@ import "./TwoPartyArbitrable.sol";
      *  @param _timeout Time after which a party automatically loose a dispute.
      *  @param _partyB The owner.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
+     *  @param _metaEvidence Link to meta-evidence JSON.
      */
-    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData) public TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData) payable {
+    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData, string _metaEvidence) public TwoPartyArbitrable(_arbitrator,_hashContract,_timeout,_partyB,_arbitratorExtraData, _metaEvidence) payable {
         amount+=msg.value;
     }
 

--- a/contracts/standard/arbitration/TwoPartyArbitrable.sol
+++ b/contracts/standard/arbitration/TwoPartyArbitrable.sol
@@ -25,7 +25,6 @@ contract TwoPartyArbitrable is Arbitrable {
     uint public disputeID;
     enum Status {NoDispute, WaitingPartyA, WaitingPartyB, DisputeCreated, Resolved}
     Status public status;
-    string public metaEvidence;
 
     uint8 constant AMOUNT_OF_CHOICES = 2;
     uint8 constant PARTY_A_WINS = 1;
@@ -55,8 +54,7 @@ contract TwoPartyArbitrable is Arbitrable {
         timeout=_timeout;
         partyA=msg.sender;
         partyB=_partyB;
-        metaEvidence=_metaEvidence;
-        emit MetaEvidence(_metaEvidence);
+        emit MetaEvidence(0, _metaEvidence);
     }
 
 
@@ -105,7 +103,7 @@ contract TwoPartyArbitrable is Arbitrable {
         status=Status.DisputeCreated;
         disputeID=arbitrator.createDispute.value(_arbitrationCost)(AMOUNT_OF_CHOICES,arbitratorExtraData);
         emit Dispute(arbitrator,disputeID,RULING_OPTIONS);
-        emit LinkMetaEvidence(arbitrator,disputeID,metaEvidence);
+        emit LinkMetaEvidence(arbitrator,disputeID,0);
     }
 
     /** @dev Reimburse partyA if partyB fails to pay the fee.

--- a/contracts/standard/arbitration/TwoPartyArbitrable.sol
+++ b/contracts/standard/arbitration/TwoPartyArbitrable.sol
@@ -44,13 +44,12 @@ contract TwoPartyArbitrable is Arbitrable {
 
     /** @dev Constructor. Choose the arbitrator.
      *  @param _arbitrator The arbitrator of the contract.
-     *  @param _hashContract Keccak hash of the plain English contract.
      *  @param _timeout Time after which a party automatically loose a dispute.
      *  @param _partyB The recipient of the transaction.
      *  @param _arbitratorExtraData Extra data for the arbitrator.
      *  @param _metaEvidence Link to the meta-evidence.
      */
-    constructor(Arbitrator _arbitrator, bytes32 _hashContract, uint _timeout, address _partyB, bytes _arbitratorExtraData, string _metaEvidence) Arbitrable(_arbitrator,_arbitratorExtraData,_hashContract) {
+    constructor(Arbitrator _arbitrator, uint _timeout, address _partyB, bytes _arbitratorExtraData, string _metaEvidence) Arbitrable(_arbitrator,_arbitratorExtraData) public {
         timeout=_timeout;
         partyA=msg.sender;
         partyB=_partyB;

--- a/contracts/standard/permission/ArbitrableBlacklist.sol
+++ b/contracts/standard/permission/ArbitrableBlacklist.sol
@@ -60,7 +60,7 @@ contract ArbitrableBlacklist is PermissionInterface, Arbitrable {
      *  @param _stake The amount in weis of deposit required for a submission or a challenge.
      *  @param _timeToChallenge The time in second, others parties have to challenge
      */
-    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, bytes32 _contractHash, uint _stake, uint _timeToChallenge) Arbitrable(_arbitrator, _arbitratorExtraData, _contractHash) public {
+    constructor(Arbitrator _arbitrator, bytes _arbitratorExtraData, uint _stake, uint _timeToChallenge) Arbitrable(_arbitrator, _arbitratorExtraData) public {
         arbitrator=_arbitrator;
         arbitratorExtraData=_arbitratorExtraData;
         stake=_stake;

--- a/contracts/standard/permission/ArbitrablePermissionList.sol
+++ b/contracts/standard/permission/ArbitrablePermissionList.sol
@@ -78,7 +78,6 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
 
     /**
      *  @dev Constructs the arbitrable permission list and sets the type.
-     *  @param _contractHash Keccak256 hash of the plain contract.
      *  @param _blacklist True if the list should function as a blacklist, false if it should function as a whitelist.
      *  @param _appendOnly True if the list should be append only.
      *  @param _arbitrator The chosen arbitrator.
@@ -87,13 +86,12 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
      *  @param _timeToChallenge The time in seconds, other parties have to challenge.
      */
     constructor(
-        bytes32 _contractHash,
         bool _blacklist,
         bool _appendOnly,
         Arbitrator _arbitrator,
         bytes _arbitratorExtraData,
         uint _stake,
-        uint _timeToChallenge) Arbitrable(_arbitrator, _arbitratorExtraData, _contractHash) public {
+        uint _timeToChallenge) Arbitrable(_arbitrator, _arbitratorExtraData) public {
         blacklist = _blacklist;
         appendOnly = _appendOnly;
         arbitrator = _arbitrator;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleros-interaction",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Smart contracts interacting with Kleros.",
   "main": "index.js",
   "scripts": {

--- a/test/arbitrableBlacklist.js
+++ b/test/arbitrableBlacklist.js
@@ -16,7 +16,6 @@ contract('ArbitrableBlacklist', function(accounts) {
   let arbitrationFee = 128
   let stake = 256
   let timeToChallenge = 0
-  let contractHash = 0x6aa0bb2779ab006be0739900654a89f1f8a2d7373ed38490a7cbab9c9392e1ff
 
   let centralizedArbitrator
   let arbitrableBlacklist
@@ -46,7 +45,7 @@ contract('ArbitrableBlacklist', function(accounts) {
       from: arbitrator
     })
 
-    arbitrableBlacklist = await ArbitrableBlacklist.new(centralizedArbitrator.address, arbitratorExtraData, contractHash, stake, timeToChallenge, {
+    arbitrableBlacklist = await ArbitrableBlacklist.new(centralizedArbitrator.address, arbitratorExtraData, stake, timeToChallenge, {
       from: arbitrator
     })
 

--- a/test/arbitrableTransaction.js
+++ b/test/arbitrableTransaction.js
@@ -4,47 +4,47 @@ const ArbitrableTransaction = artifacts.require('./ArbitrableTransaction.sol')
 const CentralizedArbitrator = artifacts.require('./CentralizedArbitrator.sol')
 
 contract('ArbitrableTransaction', function (accounts) {
-  let payer = accounts[0]
-  let payee = accounts[1]
-  let arbitrator = accounts[2]
-  let other = accounts[3]
-  let amount = 1000
-  let timeout = 100
-  let arbitrationFee = 20
-  let gasPrice = 5000000000
-  let contractHash = 0x6aa0bb2779ab006be0739900654a89f1f8a2d7373ed38490a7cbab9c9392e1ff
+  const payer = accounts[0]
+  const payee = accounts[1]
+  const arbitrator = accounts[2]
+  const other = accounts[3]
+  const amount = 1000
+  const timeout = 100
+  const arbitrationFee = 20
+  const gasPrice = 5000000000
+  const metaEvidenceUri = 'https://kleros.io'
 
   // Constructor
   it('Should put 1000 wei in the contract', async () => {
-    let arbitrableTransaction = await ArbitrableTransaction.new(0x0, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const arbitrableTransaction = await ArbitrableTransaction.new(0x0, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     assert.equal(web3.eth.getBalance(arbitrableTransaction.address), 1000, "The contract hasn't received the wei correctly.")
 
-    let amountSending = await arbitrableTransaction.amount()
+    const amountSending = await arbitrableTransaction.amount()
     assert.equal(amountSending.toNumber(), 1000, "The contract hasn't updated its amount correctly.")
   })
 
     // Pay
   it('Should pay the payee', async () => {
-    let initialPayeeBalance = web3.eth.getBalance(payee)
-    let arbitrableTransaction = await ArbitrableTransaction.new(0x0, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const initialPayeeBalance = web3.eth.getBalance(payee)
+    const arbitrableTransaction = await ArbitrableTransaction.new(0x0, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await arbitrableTransaction.pay({from: payer})
-    let newPayeeBalance = web3.eth.getBalance(payee)
+    const newPayeeBalance = web3.eth.getBalance(payee)
     assert.equal(newPayeeBalance.toString(), initialPayeeBalance.plus(1000).toString(), "The payee hasn't been paid properly")
   })
 
   it('Should not pay the payee', async () => {
-    let arbitrableTransaction = await ArbitrableTransaction.new(0x0, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const arbitrableTransaction = await ArbitrableTransaction.new(0x0, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await expectThrow(arbitrableTransaction.pay({from: payee}))
   })
 
   // Reimburse
   it('Should reimburse 507 to the payer', async () => {
-    let arbitrableTransaction = await ArbitrableTransaction.new(0x0, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
-    let payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
+    const arbitrableTransaction = await ArbitrableTransaction.new(0x0, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
+    const payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
     await arbitrableTransaction.reimburse(507, {from: payee})
-    let newPayerBalance = web3.eth.getBalance(payer)
-    let newContractBalance = web3.eth.getBalance(arbitrableTransaction.address)
-    let newAmount = await arbitrableTransaction.amount()
+    const newPayerBalance = web3.eth.getBalance(payer)
+    const newContractBalance = web3.eth.getBalance(arbitrableTransaction.address)
+    const newAmount = await arbitrableTransaction.amount()
 
     assert.equal(newPayerBalance.toString(), payerBalanceBeforeReimbursment.plus(507).toString(), 'The payer has not been reimbursed correctly')
     assert.equal(newContractBalance.toNumber(), 493, 'Bad amount in the contract')
@@ -52,12 +52,12 @@ contract('ArbitrableTransaction', function (accounts) {
   })
 
   it('Should reimburse 1000 (all) to the payer', async () => {
-    let arbitrableTransaction = await ArbitrableTransaction.new(0x0, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
-    let payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
+    const arbitrableTransaction = await ArbitrableTransaction.new(0x0, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
+    const payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
     await arbitrableTransaction.reimburse(1000, {from: payee})
-    let newPayerBalance = web3.eth.getBalance(payer)
-    let newContractBalance = web3.eth.getBalance(arbitrableTransaction.address)
-    let newAmount = await arbitrableTransaction.amount()
+    const newPayerBalance = web3.eth.getBalance(payer)
+    const newContractBalance = web3.eth.getBalance(arbitrableTransaction.address)
+    const newAmount = await arbitrableTransaction.amount()
 
     assert.equal(newPayerBalance.toString(), payerBalanceBeforeReimbursment.plus(1000).toString(), 'The payer has not been reimbursed correctly')
     assert.equal(newContractBalance.toNumber(), 0, 'Bad amount in the contract')
@@ -65,68 +65,68 @@ contract('ArbitrableTransaction', function (accounts) {
   })
 
   it('Should fail if we try to reimburse more', async () => {
-    let arbitrableTransaction = await ArbitrableTransaction.new(0x0, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const arbitrableTransaction = await ArbitrableTransaction.new(0x0, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await expectThrow(arbitrableTransaction.reimburse(1003, {from: payee}))
   })
 
   it('Should fail if the payer to it', async () => {
-    let arbitrableTransaction = await ArbitrableTransaction.new(0x0, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const arbitrableTransaction = await ArbitrableTransaction.new(0x0, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await expectThrow(arbitrableTransaction.reimburse(1000, {from: payer}))
   })
 
   // executeRuling
   it('Should reimburse the payer (including arbitration fee) when the arbitrator decides so', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await arbitrableTransaction.payArbitrationFeeByPartyA({from: payer, value: arbitrationFee})
     await arbitrableTransaction.payArbitrationFeeByPartyB({from: payee, value: arbitrationFee})
-    let payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
+    const payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
     await centralizedArbitrator.giveRuling(0, 1, {from: arbitrator})
-    let newPayerBalance = web3.eth.getBalance(payer)
+    const newPayerBalance = web3.eth.getBalance(payer)
     assert.equal(newPayerBalance.toString(), payerBalanceBeforeReimbursment.plus(1020).toString(), 'The payer has not been reimbursed correctly')
   })
 
   it('Should pay the payee and reimburse him the arbitration fee when the arbitrator decides so', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
 
     await arbitrableTransaction.payArbitrationFeeByPartyA({from: payer, value: arbitrationFee})
     await arbitrableTransaction.payArbitrationFeeByPartyB({from: payee, value: arbitrationFee})
-    let payeeBalanceBeforePay = web3.eth.getBalance(payee)
+    const payeeBalanceBeforePay = web3.eth.getBalance(payee)
     await centralizedArbitrator.giveRuling(0, 2, {from: arbitrator})
-    let newPayeeBalance = web3.eth.getBalance(payee)
+    const newPayeeBalance = web3.eth.getBalance(payee)
     assert.equal(newPayeeBalance.toString(), payeeBalanceBeforePay.plus(1020).toString(), 'The payee has not been paid properly')
   })
 
   it('It should do nothing if the arbitrator decides so', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await arbitrableTransaction.payArbitrationFeeByPartyA({from: payer, value: arbitrationFee})
     await arbitrableTransaction.payArbitrationFeeByPartyB({from: payee, value: arbitrationFee})
-    let payeeBalanceBeforePay = web3.eth.getBalance(payee)
-    let payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
+    const payeeBalanceBeforePay = web3.eth.getBalance(payee)
+    const payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
     await centralizedArbitrator.giveRuling(0, 0, {from: arbitrator})
-    let newPayeeBalance = web3.eth.getBalance(payee)
-    let newPayerBalance = web3.eth.getBalance(payer)
+    const newPayeeBalance = web3.eth.getBalance(payee)
+    const newPayerBalance = web3.eth.getBalance(payer)
     assert.equal(newPayeeBalance.toString(), payeeBalanceBeforePay.toString(), "The payee got wei while it shouldn't")
     assert.equal(newPayerBalance.toString(), payerBalanceBeforeReimbursment.toString(), "The payer got wei while it shouldn't")
   })
 
   it('Should reimburse the payer in case of timeout of the payee', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await arbitrableTransaction.payArbitrationFeeByPartyA({from: payer, value: arbitrationFee})
     increaseTime(timeout + 1)
-    let payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
-    let tx = await arbitrableTransaction.timeOutByPartyA({from: payer, gasPrice: gasPrice})
-    let txFee = tx.receipt.gasUsed * gasPrice
-    let newPayerBalance = web3.eth.getBalance(payer)
+    const payerBalanceBeforeReimbursment = web3.eth.getBalance(payer)
+    const tx = await arbitrableTransaction.timeOutByPartyA({from: payer, gasPrice: gasPrice})
+    const txFee = tx.receipt.gasUsed * gasPrice
+    const newPayerBalance = web3.eth.getBalance(payer)
     assert.equal(newPayerBalance.toString(), payerBalanceBeforeReimbursment.plus(1020).minus(txFee).toString(), 'The payer has not been reimbursed correctly')
   })
 
   it("Shouldn't work before timeout for the payer", async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await expectThrow(arbitrableTransaction.timeOutByPartyA({from: payer, gasPrice: gasPrice}))
     await arbitrableTransaction.payArbitrationFeeByPartyA({from: payer, value: arbitrationFee})
     increaseTime(1)
@@ -134,20 +134,20 @@ contract('ArbitrableTransaction', function (accounts) {
   })
 
   it('Should pay and reimburse the payee in case of timeout of the payer', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await arbitrableTransaction.payArbitrationFeeByPartyB({from: payee, value: arbitrationFee})
     increaseTime(timeout + 1)
-    let payeeBalanceBeforeReimbursment = web3.eth.getBalance(payee)
-    let tx = await arbitrableTransaction.timeOutByPartyB({from: payee, gasPrice: gasPrice})
-    let txFee = tx.receipt.gasUsed * gasPrice
-    let newPayeeBalance = web3.eth.getBalance(payee)
+    const payeeBalanceBeforeReimbursment = web3.eth.getBalance(payee)
+    const tx = await arbitrableTransaction.timeOutByPartyB({from: payee, gasPrice: gasPrice})
+    const txFee = tx.receipt.gasUsed * gasPrice
+    const newPayeeBalance = web3.eth.getBalance(payee)
     assert.equal(newPayeeBalance.toString(), payeeBalanceBeforeReimbursment.plus(1020).minus(txFee).toString(), 'The payee has not been paid correctly')
   })
 
   it("Shouldn't work before timeout for the payee", async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await expectThrow(arbitrableTransaction.timeOutByPartyB({from: payee, gasPrice: gasPrice}))
     await arbitrableTransaction.payArbitrationFeeByPartyB({from: payee, value: arbitrationFee})
     increaseTime(1)
@@ -156,11 +156,11 @@ contract('ArbitrableTransaction', function (accounts) {
 
   // submitEvidence
   it('Should create events when evidence is submitted by the payer', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await arbitrableTransaction.payArbitrationFeeByPartyA({from: payer, value: arbitrationFee})
     await arbitrableTransaction.payArbitrationFeeByPartyB({from: payee, value: arbitrationFee})
-    let tx = await arbitrableTransaction.submitEvidence('ipfs:/X', {from: payer})
+    const tx = await arbitrableTransaction.submitEvidence('ipfs:/X', {from: payer})
     assert.equal(tx.logs[0].event, 'Evidence')
     assert.equal(tx.logs[0].args._arbitrator, centralizedArbitrator.address)
     assert.equal(tx.logs[0].args._party, payer)
@@ -168,11 +168,11 @@ contract('ArbitrableTransaction', function (accounts) {
   })
 
   it('Should create events when evidence is submitted by the payee', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await arbitrableTransaction.payArbitrationFeeByPartyA({from: payer, value: arbitrationFee})
     await arbitrableTransaction.payArbitrationFeeByPartyB({from: payee, value: arbitrationFee})
-    let tx = await arbitrableTransaction.submitEvidence('ipfs:/X', {from: payee})
+    const tx = await arbitrableTransaction.submitEvidence('ipfs:/X', {from: payee})
     assert.equal(tx.logs[0].event, 'Evidence')
     assert.equal(tx.logs[0].args._arbitrator, centralizedArbitrator.address)
     assert.equal(tx.logs[0].args._party, payee)
@@ -180,8 +180,8 @@ contract('ArbitrableTransaction', function (accounts) {
   })
 
   it('Should fail if someone else try to submit', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, contractHash, timeout, payee, 0x0, {from: payer, value: amount})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrableTransaction = await ArbitrableTransaction.new(centralizedArbitrator.address, timeout, payee, 0x0, metaEvidenceUri, {from: payer, value: amount})
     await arbitrableTransaction.payArbitrationFeeByPartyA({from: payer, value: arbitrationFee})
     await arbitrableTransaction.payArbitrationFeeByPartyB({from: payee, value: arbitrationFee})
     await expectThrow(arbitrableTransaction.submitEvidence('ipfs:/X', {from: other}))

--- a/test/multipleArbitrableTransaction.js
+++ b/test/multipleArbitrableTransaction.js
@@ -6,21 +6,21 @@ const MultipleArbitrableTransaction = artifacts.require(
 const CentralizedArbitrator = artifacts.require("./CentralizedArbitrator.sol");
 
 contract("MultipleArbitrableTransaction", function(accounts) {
-  let payer = accounts[0];
-  let payee = accounts[1];
-  let arbitrator = accounts[2];
-  let other = accounts[3];
-  let amount = 1000;
-  let timeout = 100;
-  let arbitrationFee = 20;
-  let gasPrice = 5000000000;
-  let contractHash = 0x6aa0bb2779ab006be0739900654a89f1f8a2d7373ed38490a7cbab9c9392e1ff;
+  let payer = accounts[0]
+  let payee = accounts[1]
+  let arbitrator = accounts[2]
+  let other = accounts[3]
+  let amount = 1000
+  let timeout = 100
+  let arbitrationFee = 20
+  let gasPrice = 5000000000
+  const metaEvidenceUri = 'https://kleros.io'
 
   async function getLastTransaction(multipleContract, callback) {
-    const contractHashEvent = multipleContract.ContractHash();
+    const metaEvidenceEvent = multipleContract.MetaEvidence();
     const awaitable = new Promise((resolve, reject) => {
-      const handler = contractHashEvent.watch((error, result) => {
-        contractHashEvent.stopWatching();
+      const handler = metaEvidenceEvent.watch((error, result) => {
+        metaEvidenceEvent.stopWatching();
         if (!error) {
           resolve(result);
         } else {
@@ -41,10 +41,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           0x0,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -84,10 +84,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
         async () => {
           await multipleContract.createTransaction(
             0x0,
-            contractHash,
             timeout,
             payee,
             0x0,
+            metaEvidenceUri,
             { from: payer, value: amount }
           );
         }
@@ -128,10 +128,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           0x0,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -166,10 +166,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           0x0,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -199,10 +199,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           0x0,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -223,10 +223,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           0x0,
-          contractHash,
           0 /* timeout */,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -266,10 +266,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           0x0,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -309,10 +309,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           0x0,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -334,10 +334,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           0x0,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -365,10 +365,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -407,10 +407,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -449,10 +449,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -499,10 +499,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -546,10 +546,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -590,10 +590,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -637,10 +637,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -682,10 +682,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -726,10 +726,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -770,10 +770,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       async () => {
         await multipleContract.createTransaction(
           centralizedArbitrator.address,
-          contractHash,
           timeout,
           payee,
           0x0,
+          metaEvidenceUri,
           { from: payer, value: amount }
         );
       }
@@ -805,11 +805,11 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       from: payer
     });
 
-    const contractHashEvent = multipleContract.ContractHash();
+    const metaEvidenceEvent = multipleContract.MetaEvidence();
 
     let currentResolve;
     let lastTransactionEvent = -1;
-    const handler = contractHashEvent.watch((error, result) => {
+    const handler = metaEvidenceEvent.watch((error, result) => {
       const eventTransaction = result.args._transactionId.toNumber();
       if (eventTransaction > lastTransactionEvent) {
         lastTransactionEvent = eventTransaction;
@@ -822,10 +822,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
 
       multipleContract.createTransaction(
         centralizedArbitrator.address,
-        contractHash,
         timeout,
         payee,
         0x0,
+        metaEvidenceUri,
         { from: payer, value: amount }
       );
     });
@@ -839,10 +839,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
 
       multipleContract.createTransaction(
         centralizedArbitrator.address,
-        contractHash,
         timeout,
         payee,
         0x0,
+        metaEvidenceUri,
         { from: payer, value: amount }
       );
     });
@@ -851,7 +851,7 @@ contract("MultipleArbitrableTransaction", function(accounts) {
 
     let arbitrableTransactionId2 = lastTransaction2.args._transactionId.toNumber();
 
-    contractHashEvent.stopWatching();
+    metaEvidenceEvent.stopWatching();
 
     await multipleContract.payArbitrationFeeByBuyer(arbitrableTransactionId2, {
       from: payer,
@@ -907,11 +907,11 @@ contract("MultipleArbitrableTransaction", function(accounts) {
       from: payer
     });
 
-    const contractHashEvent = multipleContract.ContractHash();
+    const metaEvidenceEvent = multipleContract.MetaEvidence();
 
     let currentResolve;
     let lastTransactionEvent = -1;
-    const handler = contractHashEvent.watch((error, result) => {
+    const handler = metaEvidenceEvent.watch((error, result) => {
       const eventTransaction = result.args._transactionId.toNumber();
       if (eventTransaction > lastTransactionEvent) {
         lastTransactionEvent = eventTransaction;
@@ -924,10 +924,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
 
       multipleContract.createTransaction(
         centralizedArbitrator1.address,
-        contractHash,
         timeout,
         payee,
         0x0,
+        metaEvidenceUri,
         { from: payer, value: amount }
       );
     });
@@ -941,10 +941,10 @@ contract("MultipleArbitrableTransaction", function(accounts) {
 
       multipleContract.createTransaction(
         centralizedArbitrator2.address,
-        contractHash,
         timeout,
         payee,
         0x0,
+        metaEvidenceUri,
         { from: payer, value: amount }
       );
     });
@@ -953,7 +953,7 @@ contract("MultipleArbitrableTransaction", function(accounts) {
 
     let arbitrableTransactionId2 = lastTransaction2.args._transactionId.toNumber();
 
-    contractHashEvent.stopWatching();
+    metaEvidenceEvent.stopWatching();
 
     await multipleContract.payArbitrationFeeByBuyer(arbitrableTransactionId2, {
       from: payer,

--- a/test/twoPartyArbitrable.js
+++ b/test/twoPartyArbitrable.js
@@ -4,19 +4,19 @@ const TwoPartyArbitrable = artifacts.require('./TwoPartyArbitrable.sol')
 const CentralizedArbitrator = artifacts.require('./CentralizedArbitrator.sol')
 
 contract('TwoPartyArbitrable', function (accounts) {
-  let partyA = accounts[0]
-  let partyB = accounts[1]
-  let arbitrator = accounts[2]
-  let other = accounts[3]
-  let timeout = 100
-  let arbitrationFee = 20
-  let gasPrice = 5000000000
+  const partyA = accounts[0]
+  const partyB = accounts[1]
+  const arbitrator = accounts[2]
+  const other = accounts[3]
+  const timeout = 100
+  const arbitrationFee = 20
+  const gasPrice = 5000000000
   const metaEvidenceUri = 'https://kleros.io'
 
   // Constructor
   it('Should set the correct values', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
     assert.equal(await arbitrable.timeout(), timeout)
     assert.equal(await arbitrable.partyA(), partyA)
     assert.equal(await arbitrable.partyB(), partyB)
@@ -25,30 +25,30 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   // payArbitrationFeeByPartyA and payArbitrationFeeByPartyB
   it('Should create a dispute when A and B pay', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
-    let dispute = await centralizedArbitrator.disputes(0)
+    const dispute = await centralizedArbitrator.disputes(0)
     assert.equal(dispute[0], arbitrable.address, 'Arbitrable not set up properly')
     assert.equal(dispute[1].toNumber(), 2, 'Number of choices not set up properly')
     assert.equal(dispute[2].toNumber(), 20, 'Fee not set up properly')
   })
 
   it('Should create a dispute when B and A pay', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
-    let dispute = await centralizedArbitrator.disputes(0)
+    const dispute = await centralizedArbitrator.disputes(0)
     assert.equal(dispute[0], arbitrable.address, 'Arbitrable not set up properly')
     assert.equal(dispute[1].toNumber(), 2, 'Number of choices not set up properly')
     assert.equal(dispute[2].toNumber(), 20, 'Fee not set up properly')
   })
 
   it('Should not be possible to pay less', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
     await expectThrow(arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee - 1}))
     await expectThrow(arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee - 1}))
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
@@ -56,22 +56,81 @@ contract('TwoPartyArbitrable', function (accounts) {
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
   })
 
+  // meta-evidence
+  it('Should create MetaEvidence event on contract creation', async () => {
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const metaEvidenceEvents = await new Promise((resolve, reject) => {
+      arbitrable.MetaEvidence({}, {
+          fromBlock: 0,
+          toBlock: 'latest'
+        })
+        .get((error, result) => {
+          if (error) reject()
+
+          resolve(result)
+        })
+    })
+
+    assert.equal(metaEvidenceEvents.length, 1, 'Meta Evidence event was not created')
+    assert.equal(metaEvidenceEvents[0].args._evidence, metaEvidenceUri)
+  })
+  
+  it('Should link MetaEvidence event on dispute creation', async () => {
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const metaEvidenceEvents = await new Promise((resolve, reject) => {
+      arbitrable.MetaEvidence({}, {
+          fromBlock: 0,
+          toBlock: 'latest'
+        })
+        .get((error, result) => {
+          if (error) reject()
+
+          resolve(result)
+        })
+    })
+    assert.equal(metaEvidenceEvents.length, 1, 'Meta Evidence event was not created')
+    const metaEvidenceId = metaEvidenceEvents[0].args._metaEvidenceID.toNumber()
+
+    await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
+    await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
+    const dispute = await centralizedArbitrator.disputes(0)
+    assert.equal(dispute[0], arbitrable.address, 'No dispute created')
+    const metaEvidenceLinkEvents = await new Promise((resolve, reject) => {
+      arbitrable.LinkMetaEvidence({}, {
+          fromBlock: 0,
+          toBlock: 'latest'
+        })
+        .get((error, result) => {
+          if (error) reject()
+
+          resolve(result)
+        })
+    })
+
+    assert.equal(metaEvidenceLinkEvents.length, 1, 'Meta Evidence event was not created')
+    assert.equal(metaEvidenceLinkEvents[0].args._arbitrator, centralizedArbitrator.address)
+    assert.equal(metaEvidenceLinkEvents[0].args._disputeID.toNumber(), 0)
+    assert.equal(metaEvidenceLinkEvents[0].args._metaEvidenceID.toNumber(), metaEvidenceId)
+  })
+
   // timeOutByPartyA and timeOutByPartyB
   it('Should reimburse partyA in case of timeout of partyB', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     increaseTime(timeout + 1)
-    let partyABalanceBeforeReimbursment = web3.eth.getBalance(partyA)
-    let tx = await arbitrable.timeOutByPartyA({from: partyA, gasPrice: gasPrice})
-    let txFee = tx.receipt.gasUsed * gasPrice
-    let newpartyABalance = web3.eth.getBalance(partyA)
+    const partyABalanceBeforeReimbursment = web3.eth.getBalance(partyA)
+    const tx = await arbitrable.timeOutByPartyA({from: partyA, gasPrice: gasPrice})
+    const txFee = tx.receipt.gasUsed * gasPrice
+    const newpartyABalance = web3.eth.getBalance(partyA)
     assert.equal(newpartyABalance.toString(), partyABalanceBeforeReimbursment.plus(20).minus(txFee).toString(), 'partyA has not been reimbursed correctly')
   })
 
   it("Shouldn't work before timeout for partyA", async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await expectThrow(arbitrable.timeOutByPartyA({from: partyA, gasPrice: gasPrice}))
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     increaseTime(1)
@@ -79,20 +138,20 @@ contract('TwoPartyArbitrable', function (accounts) {
   })
 
   it('Should reimburse partyB in case of timeout of partyA', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     increaseTime(timeout + 1)
-    let partyBBalanceBeforeReimbursment = web3.eth.getBalance(partyB)
-    let tx = await arbitrable.timeOutByPartyB({from: partyB, gasPrice: gasPrice})
-    let txFee = tx.receipt.gasUsed * gasPrice
-    let newpartyBBalance = web3.eth.getBalance(partyB)
+    const partyBBalanceBeforeReimbursment = web3.eth.getBalance(partyB)
+    const tx = await arbitrable.timeOutByPartyB({from: partyB, gasPrice: gasPrice})
+    const txFee = tx.receipt.gasUsed * gasPrice
+    const newpartyBBalance = web3.eth.getBalance(partyB)
     assert.equal(newpartyBBalance.toString(), partyBBalanceBeforeReimbursment.plus(20).minus(txFee).toString(), 'partyB has not been reimbursed correctly')
   })
 
   it("Shouldn't work before timeout for partyB", async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await expectThrow(arbitrable.timeOutByPartyB({from: partyB, gasPrice: gasPrice}))
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     increaseTime(1)
@@ -101,11 +160,11 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   // submitEvidence
   it('Should create events when evidence is submitted by partyA', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
-    let tx = await arbitrable.submitEvidence('ipfs:/X', {from: partyA})
+    const tx = await arbitrable.submitEvidence('ipfs:/X', {from: partyA})
     assert.equal(tx.logs[0].event, 'Evidence')
     assert.equal(tx.logs[0].args._arbitrator, centralizedArbitrator.address)
     assert.equal(tx.logs[0].args._party, partyA)
@@ -113,11 +172,11 @@ contract('TwoPartyArbitrable', function (accounts) {
   })
 
   it('Should create events when evidence is submitted by partyB', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
-    let tx = await arbitrable.submitEvidence('ipfs:/X', {from: partyB})
+    const tx = await arbitrable.submitEvidence('ipfs:/X', {from: partyB})
     assert.equal(tx.logs[0].event, 'Evidence')
     assert.equal(tx.logs[0].args._arbitrator, centralizedArbitrator.address)
     assert.equal(tx.logs[0].args._party, partyB)
@@ -125,8 +184,8 @@ contract('TwoPartyArbitrable', function (accounts) {
   })
 
   it('Should fail if someone else tries to submit', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     await expectThrow(arbitrable.submitEvidence('ipfs:/X', {from: other}))
@@ -137,37 +196,37 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   // executeRuling
   it('Should reimburse the partyA (including arbitration fee) when the arbitrator decides so', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
-    let partyABalanceBeforeReimbursment = web3.eth.getBalance(partyA)
+    const partyABalanceBeforeReimbursment = web3.eth.getBalance(partyA)
     await centralizedArbitrator.giveRuling(0, 1, {from: arbitrator})
-    let newPartyABalance = web3.eth.getBalance(partyA)
+    const newPartyABalance = web3.eth.getBalance(partyA)
     assert.equal(newPartyABalance.toString(), partyABalanceBeforeReimbursment.plus(20).toString(), 'partyA has not been reimbursed correctly')
   })
 
   it('Should pay the partyB and reimburse him the arbitration fee when the arbitrator decides so', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
-    let partyBBalanceBeforePay = web3.eth.getBalance(partyB)
+    const partyBBalanceBeforePay = web3.eth.getBalance(partyB)
     await centralizedArbitrator.giveRuling(0, 2, {from: arbitrator})
-    let newPartyBBalance = web3.eth.getBalance(partyB)
+    const newPartyBBalance = web3.eth.getBalance(partyB)
     assert.equal(newPartyBBalance.toString(), partyBBalanceBeforePay.plus(20).toString(), 'partyB has not been reimbursed correctly')
   })
 
   it('It should do nothing if the arbitrator decides so', async () => {
-    let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
+    const centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
+    const arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
-    let partyBBalanceBeforePay = web3.eth.getBalance(partyB)
-    let partyABalanceBeforeReimbursment = web3.eth.getBalance(partyA)
+    const partyBBalanceBeforePay = web3.eth.getBalance(partyB)
+    const partyABalanceBeforeReimbursment = web3.eth.getBalance(partyA)
     await centralizedArbitrator.giveRuling(0, 0, {from: arbitrator})
-    let newPartyBBalance = web3.eth.getBalance(partyB)
-    let newPartyABalance = web3.eth.getBalance(partyA)
+    const newPartyBBalance = web3.eth.getBalance(partyB)
+    const newPartyABalance = web3.eth.getBalance(partyA)
     assert.equal(newPartyBBalance.toString(), partyBBalanceBeforePay.toString(), "partyB got wei while it shouldn't")
     assert.equal(newPartyABalance.toString(), partyABalanceBeforeReimbursment.toString(), "partyA got wei while it shouldn't")
   })

--- a/test/twoPartyArbitrable.js
+++ b/test/twoPartyArbitrable.js
@@ -11,12 +11,12 @@ contract('TwoPartyArbitrable', function (accounts) {
   let timeout = 100
   let arbitrationFee = 20
   let gasPrice = 5000000000
-  let contractHash = 0x6aa0bb2779ab006be0739900654a89f1f8a2d7373ed38490a7cbab9c9392e1ff
+  const metaEvidenceUri = 'https://kleros.io'
 
   // Constructor
   it('Should set the correct values', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x08575, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
     assert.equal(await arbitrable.timeout(), timeout)
     assert.equal(await arbitrable.partyA(), partyA)
     assert.equal(await arbitrable.partyB(), partyB)
@@ -26,7 +26,7 @@ contract('TwoPartyArbitrable', function (accounts) {
   // payArbitrationFeeByPartyA and payArbitrationFeeByPartyB
   it('Should create a dispute when A and B pay', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x08575, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     let dispute = await centralizedArbitrator.disputes(0)
@@ -37,7 +37,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it('Should create a dispute when B and A pay', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x08575, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     let dispute = await centralizedArbitrator.disputes(0)
@@ -48,7 +48,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it('Should not be possible to pay less', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x08575, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x08575, metaEvidenceUri, {from: partyA})
     await expectThrow(arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee - 1}))
     await expectThrow(arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee - 1}))
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
@@ -59,7 +59,7 @@ contract('TwoPartyArbitrable', function (accounts) {
   // timeOutByPartyA and timeOutByPartyB
   it('Should reimburse partyA in case of timeout of partyB', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     increaseTime(timeout + 1)
     let partyABalanceBeforeReimbursment = web3.eth.getBalance(partyA)
@@ -71,7 +71,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it("Shouldn't work before timeout for partyA", async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await expectThrow(arbitrable.timeOutByPartyA({from: partyA, gasPrice: gasPrice}))
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     increaseTime(1)
@@ -80,7 +80,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it('Should reimburse partyB in case of timeout of partyA', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     increaseTime(timeout + 1)
     let partyBBalanceBeforeReimbursment = web3.eth.getBalance(partyB)
@@ -92,7 +92,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it("Shouldn't work before timeout for partyB", async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await expectThrow(arbitrable.timeOutByPartyB({from: partyB, gasPrice: gasPrice}))
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     increaseTime(1)
@@ -102,7 +102,7 @@ contract('TwoPartyArbitrable', function (accounts) {
   // submitEvidence
   it('Should create events when evidence is submitted by partyA', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     let tx = await arbitrable.submitEvidence('ipfs:/X', {from: partyA})
@@ -114,7 +114,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it('Should create events when evidence is submitted by partyB', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     let tx = await arbitrable.submitEvidence('ipfs:/X', {from: partyB})
@@ -126,7 +126,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it('Should fail if someone else tries to submit', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     await expectThrow(arbitrable.submitEvidence('ipfs:/X', {from: other}))
@@ -138,7 +138,7 @@ contract('TwoPartyArbitrable', function (accounts) {
   // executeRuling
   it('Should reimburse the partyA (including arbitration fee) when the arbitrator decides so', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     let partyABalanceBeforeReimbursment = web3.eth.getBalance(partyA)
@@ -149,7 +149,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it('Should pay the partyB and reimburse him the arbitration fee when the arbitrator decides so', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     let partyBBalanceBeforePay = web3.eth.getBalance(partyB)
@@ -160,7 +160,7 @@ contract('TwoPartyArbitrable', function (accounts) {
 
   it('It should do nothing if the arbitrator decides so', async () => {
     let centralizedArbitrator = await CentralizedArbitrator.new(arbitrationFee, {from: arbitrator})
-    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, contractHash, timeout, partyB, 0x0, {from: partyA})
+    let arbitrable = await TwoPartyArbitrable.new(centralizedArbitrator.address, timeout, partyB, 0x0, metaEvidenceUri, {from: partyA})
     await arbitrable.payArbitrationFeeByPartyA({from: partyA, value: arbitrationFee})
     await arbitrable.payArbitrationFeeByPartyB({from: partyB, value: arbitrationFee})
     let partyBBalanceBeforePay = web3.eth.getBalance(partyB)


### PR DESCRIPTION
- Add MetaEvidence events to `Arbitrable.sol`
- `TwoPartyArbitrable.sol` takes metaEvidence as a argument and emits events