### PR TITLE
refactor: change visibility of blacklist and appendOnly to public

### DIFF
--- a/contracts/standard/permission/ArbitrablePermissionList.sol
+++ b/contracts/standard/permission/ArbitrablePermissionList.sol
@@ -57,8 +57,8 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
     /* Storage */
 
     // Settings
-    bool blacklist; // True if the list should function as a blacklist, false if it should function as a whitelist.
-    bool appendOnly; // True if the list should be append only.
+    bool public blacklist; // True if the list should function as a blacklist, false if it should function as a whitelist.
+    bool public appendOnly; // True if the list should be append only.
     Arbitrator public arbitrator;
     bytes public arbitratorExtraData;
     uint public stake;


### PR DESCRIPTION
The new `blacklist` and `appendOnly` are the only setting variables which are not public. Is there a reason?

One reason to make them public is testability. While testing, I realized that I can't access them. 

Setting them public only gives read access by auto-generated getters, so it should be safe.