### PR TITLE
Refactor: move maxLocalAppeals from ArbitratorCourt to Arbitrator 

### DIFF
--- a/contracts/standard/arbitration/Arbitrator.sol
+++ b/contracts/standard/arbitration/Arbitrator.sol
@@ -17,10 +17,18 @@ import "./Arbitrable.sol";
  */
 contract Arbitrator{
 
+    uint public maxAppeals; // Number of times a dispute can be appealed.
     enum DisputeStatus {Waiting, Appealable, Solved}
 
     modifier requireArbitrationFee(bytes _extraData) {require(msg.value>=arbitrationCost(_extraData)); _;}
     modifier requireAppealFee(uint _disputeID, bytes _extraData) {require(msg.value>=appealCost(_disputeID, _extraData)); _;}
+
+    /** @dev Constructor.
+     *  @param _maxAppeals Number of times a dispute can be appealed.
+     */
+    constructor(uint _maxAppeals) public {
+      maxAppeals = _maxAppeals;
+    }
 
     /** @dev To be raised when a dispute can be appealed.
      *  @param _disputeID ID of the dispute.

--- a/contracts/standard/arbitration/ArbitratorCourt.sol
+++ b/contracts/standard/arbitration/ArbitratorCourt.sol
@@ -48,7 +48,6 @@ contract ArbitratorCourt is Arbitrator {
     address public owner = msg.sender;
 
     // Courts
-    uint256 maxLocalAppeals;
     Court parent; // Appeal to this arbitrator if it is set, otherwise reject appeal and finalize decision.
     Court[] subCourts;
 
@@ -66,12 +65,10 @@ contract ArbitratorCourt is Arbitrator {
 
     /**
      *  @notice Constructs the arbitrator court with an initial parent and the maximum number of local appeals.
-     *  @param _maxLocalAppeals The maximum number of local appeals.
      *  @param _parentName The name of the `parent`.
      *  @param _parentAddress The address of the `parent`.
      */
-    constructor(uint256 _maxLocalAppeals, string _parentName, Arbitrator _parentAddress) public {
-        maxLocalAppeals = _maxLocalAppeals;
+    constructor(string _parentName, Arbitrator _parentAddress) public {
         parent = Court({ name: _parentName, _address: _parentAddress });
     }
 


### PR DESCRIPTION
Refactored `maxLocalAppeals` by moving from `ArbitratorCourt` to `Arbitrator` and by renaming to `maxAppeals`.

Related to https://github.com/kleros/kleros/issues/47

Please review @clesaege  @epiqueras 