### PR TITLE
isPermitted logic was flipped. Renaming function

### DIFF
--- a/contracts/standard/permission/ArbitrablePermissionList.sol
+++ b/contracts/standard/permission/ArbitrablePermissionList.sol
@@ -49,14 +49,14 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
      *  @param submitter Address of the submitter, if any.
      *  @param challenger Address of the challenger, if any.
      *  @param value The value of the item.
-     *  @param newStatus The new status of the item.
+     *  @param status The status of the item.
      *  @param disputed The item is being disputed.
      */
     event ItemStatusChange(
         address indexed submitter,
         address indexed challenger,
         bytes32 indexed value,
-        ItemStatus newStatus,
+        ItemStatus status,
         bool disputed
     );
 
@@ -112,7 +112,7 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
      *  @dev Request for an item to be registered.
      *  @param _value The value of the item to register.
      */
-    function requestRegisterItem(bytes32 _value) public payable {
+    function requestRegistration(bytes32 _value) public payable {
         Item storage item = items[_value];
         uint arbitratorCost = arbitrator.arbitrationCost(arbitratorExtraData);
         require(msg.value >= stake + arbitratorCost);
@@ -137,7 +137,7 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
      *  @dev Request an item to be cleared.
      *  @param _value The value of the item to clear.
      */
-    function requestClearItem(bytes32 _value) public payable {
+    function requestClearing(bytes32 _value) public payable {
         Item storage item = items[_value];
         uint arbitratorCost = arbitrator.arbitrationCost(arbitratorExtraData);
         require(!appendOnly);
@@ -161,7 +161,7 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
      *  @dev Challenge a registration request.
      *  @param _value The value of the item subject to the registering request.
      */
-    function challengeRegisterItem(bytes32 _value) public payable {
+    function challengeRegistration(bytes32 _value) public payable {
         Item storage item = items[_value];
         uint arbitratorCost = arbitrator.arbitrationCost(arbitratorExtraData);
         require(msg.value >= stake + arbitratorCost);
@@ -194,7 +194,7 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
      *  @dev Challenge a clearing request.
      *  @param _value The value of the item subject to the clearing request.
      */
-    function challengeClearItem(bytes32 _value) public payable {
+    function challengeClearing(bytes32 _value) public payable {
         Item storage item = items[_value];
         uint arbitratorCost = arbitrator.arbitrationCost(arbitratorExtraData);
         require(msg.value >= stake + arbitratorCost);
@@ -262,9 +262,9 @@ contract ArbitrablePermissionList is PermissionInterface, Arbitrable {
      */
     function isPermitted(bytes32 _value) public view returns (bool allowed) {
         Item storage item = items[_value];
-        bool _offList = item.status <= ItemStatus.Resubmitted ||
+        bool _excluded = item.status <= ItemStatus.Resubmitted ||
             (item.status == ItemStatus.PreventiveClearingRequested && !item.disputed);
-        return blacklist ? _offList : !_offList; // Items off of blacklist should return as true.
+        return blacklist ? _excluded : !_excluded; // Items excluded from blacklist should return true.
     }
 
     /* Internal */

--- a/test/arbitrablePermissionList.js
+++ b/test/arbitrablePermissionList.js
@@ -68,7 +68,7 @@ contract('ArbitrablePermissionList', function(accounts) {
     });
 
     before('populate the list', async function (){
-      await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+      await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
         from: partyA,
         value: stake + arbitrationCost
       })
@@ -169,32 +169,32 @@ contract('ArbitrablePermissionList', function(accounts) {
         describe('msg.value restrictions', function() {
           describe('Should revert when msg.value < stake+arbitratorCost', function() {
 
-            it('requestRegistering', async () => {
-              await expectThrow(arbitrablePermissionList.requestRegistering(
+            it('requestRegisterItem', async () => {
+              await expectThrow(arbitrablePermissionList.requestRegisterItem(
                 ARBITRARY_STRING, {
                   from: arbitrator,
                   value: stake + arbitrationCost - 1
                 }))
             });
 
-            it('requestClearing', async () => {
-              await expectThrow(arbitrablePermissionList.requestClearing(
+            it('requestClearItem', async () => {
+              await expectThrow(arbitrablePermissionList.requestClearItem(
                 ARBITRARY_STRING, {
                   from: arbitrator,
                   value: stake + arbitrationCost - 1
                 }))
             });
 
-            it('challengeRegistering', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegistering(
+            it('challengeRegisterItem', async () => {
+              await expectThrow(arbitrablePermissionList.challengeRegisterItem(
                 ARBITRARY_STRING, {
                   from: arbitrator,
                   value: stake + arbitrationCost - 1
                 }))
             });
 
-            it('challengeClearing', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegistering(
+            it('challengeClearItem', async () => {
+              await expectThrow(arbitrablePermissionList.challengeRegisterItem(
                 ARBITRARY_STRING, {
                   from: arbitrator,
                   value: stake + arbitrationCost - 1
@@ -206,12 +206,12 @@ contract('ArbitrablePermissionList', function(accounts) {
         describe('When item.disputed', function() {
 
           beforeEach('prepare pre-conditions to satisfy other requirements', async function() {
-            await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+            await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }); // To satisfy `require(item.status==ItemStatus.Resubmitted || item.status==ItemStatus.Submitted)`
 
-            await arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+            await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }) // To dissatisfy `require(!item.disputed)`
@@ -222,16 +222,16 @@ contract('ArbitrablePermissionList', function(accounts) {
 
             assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[5], true)
           });
-          it('challengeRegistering', async () => {
-            await expectThrow(arbitrablePermissionList.challengeRegistering(
+          it('challengeRegisterItem', async () => {
+            await expectThrow(arbitrablePermissionList.challengeRegisterItem(
               ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
           });
 
-          it('challengeClearing', async () => {
-            await expectThrow(arbitrablePermissionList.challengeClearing(
+          it('challengeClearItem', async () => {
+            await expectThrow(arbitrablePermissionList.challengeClearItem(
               ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
@@ -245,16 +245,16 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.ok((await arbitrablePermissionList.items(ARBITRARY_STRING))[0] < ITEM_STATUS.CLEARING_REQUESTED)
           });
 
-          it('challengeRegistering', async function() {
-            await expectThrow(arbitrablePermissionList.challengeRegistering(
+          it('challengeRegisterItem', async function() {
+            await expectThrow(arbitrablePermissionList.challengeRegisterItem(
               ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
           });
 
-          it('challengeClearing', async function() {
-            await expectThrow(arbitrablePermissionList.challengeClearing(
+          it('challengeClearItem', async function() {
+            await expectThrow(arbitrablePermissionList.challengeClearItem(
               ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
@@ -270,12 +270,12 @@ contract('ArbitrablePermissionList', function(accounts) {
 
           });
 
-          it('calling isPermitted should return ' + (!blacklist), async () => {
-            assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
+          it('calling isPermitted should return ' + (blacklist), async () => {
+            assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
           });
 
-          it('calling requestRegistering should move item into the submitted state', async () => {
-            await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+          it('calling requestRegisterItem should move item into the submitted state', async () => {
+            await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             });
@@ -284,8 +284,8 @@ contract('ArbitrablePermissionList', function(accounts) {
           });
 
           if (!appendOnly) {
-            it('calling requestClearing should move item into the preventive clearing requested state', async () => {
-              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+            it('calling requestClearItem should move item into the preventive clearing requested state', async () => {
+              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -293,8 +293,8 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0].toNumber(), ITEM_STATUS.PREVENTIVE_CLEARING_REQUESTED)
             })
           } else {
-            it('calling requestClearing should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+            it('calling requestClearItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
@@ -303,14 +303,14 @@ contract('ArbitrablePermissionList', function(accounts) {
 
 
           it('calling challangeBlacklisting should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+            await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
           });
 
           it('calling challangeClearing should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+            await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
@@ -327,14 +327,14 @@ contract('ArbitrablePermissionList', function(accounts) {
           describe('When item in cleared state', function() {
 
             beforeEach('prepare pre-conditions', async function() {
-              await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
               await arbitrablePermissionList.executeRequest(ARBITRARY_STRING, {
                 from: arbitrator
               });
-              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -347,12 +347,12 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0], ITEM_STATUS.CLEARED)
             });
 
-            it('calling isPermitted should return ' + (!blacklist), async () => {
-              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
+            it('calling isPermitted should return ' + (blacklist), async () => {
+              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
             });
 
-            it('calling requestRegistering should move item into the resubmitted state', async () => {
-              await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+            it('calling requestRegisterItem should move item into the resubmitted state', async () => {
+              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -360,22 +360,22 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0].toNumber(), ITEM_STATUS.RESUBMITTED)
             });
 
-            it('calling requestClearing should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+            it('calling requestClearItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
             });
 
             it('calling challangeBlacklisting should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+              await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
             });
 
             it('calling challangeClearing should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+              await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
@@ -394,21 +394,21 @@ contract('ArbitrablePermissionList', function(accounts) {
           describe('When item in resubmitted state', function() {
 
             beforeEach('prepare pre-conditions', async function() {
-              await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               });
               await arbitrablePermissionList.executeRequest(ARBITRARY_STRING, {
                 from: partyA
               });
-              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               });
               await arbitrablePermissionList.executeRequest(ARBITRARY_STRING, {
                 from: partyB
               });
-              await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               })
@@ -419,19 +419,19 @@ contract('ArbitrablePermissionList', function(accounts) {
 
             });
 
-            it('calling isPermitted should return true ' + (!blacklist), async () => {
-              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
+            it('calling isPermitted should return true ' + (blacklist), async () => {
+              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
             });
 
-            it('calling requestRegistering should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+            it('calling requestRegisterItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling requestClearing should revert', async function() {
-              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+            it('calling requestClearItem should revert', async function() {
+              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
@@ -440,7 +440,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             it('calling challengeBlacklisting should create a dispute', async function() {
               let itemBalance = (await arbitrablePermissionList.items(ARBITRARY_STRING))[4].toNumber();
 
-              await arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -452,8 +452,8 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal(web3.toUtf8(await arbitrablePermissionList.disputeIDToItem(disputeID)), ARBITRARY_STRING)
             });
 
-            it('calling challengeClearing should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+            it('calling challengeClearItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
@@ -471,7 +471,7 @@ contract('ArbitrablePermissionList', function(accounts) {
               let disputeID;
 
               beforeEach('create a dispute', async function() {
-                await arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+                await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
                   from: partyB,
                   value: stake + arbitrationCost
                 });
@@ -543,7 +543,7 @@ contract('ArbitrablePermissionList', function(accounts) {
         describe('When item in registered state', function() {
 
           beforeEach('prepare pre-conditions', async function() {
-            await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+            await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             });
@@ -556,20 +556,20 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0], ITEM_STATUS.REGISTERED)
           });
 
-          it('calling isPermitted should return ' + (blacklist), async () => {
-            assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
+          it('calling isPermitted should return ' + (!blacklist), async () => {
+            assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
           });
 
-          it('calling requestRegistering should revert', async () => {
-            await expectThrow(arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+          it('calling requestRegisterItem should revert', async () => {
+            await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
           });
 
           if (!appendOnly) {
-            it('calling requestClearing should move item into the clearing requested state', async () => {
-              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+            it('calling requestClearItem should move item into the clearing requested state', async () => {
+              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -579,23 +579,23 @@ contract('ArbitrablePermissionList', function(accounts) {
                 ITEM_STATUS.CLEARING_REQUESTED)
             })
           } else {
-            it('calling requestClearing should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+            it('calling requestClearItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
             })
           }
 
-          it('calling challengeRegistering should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+          it('calling challengeRegisterItem should revert', async () => {
+            await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
           });
 
-          it('calling challengeClearing should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+          it('calling challengeClearItem should revert', async () => {
+            await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
@@ -611,7 +611,7 @@ contract('ArbitrablePermissionList', function(accounts) {
         describe('When item in submitted state', function() {
 
           beforeEach('prepare pre-conditions', async function() {
-            await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+            await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             })
@@ -621,19 +621,19 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0].toNumber(), ITEM_STATUS.SUBMITTED)
           });
 
-          it('calling isPermitted should return ' + (blacklist), async () => {
-            assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
+          it('calling isPermitted should return ' + (!blacklist), async () => {
+            assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
           });
 
-          it('calling requestRegistering should revert', async () => {
-            await expectThrow(arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+          it('calling requestRegisterItem should revert', async () => {
+            await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
           });
 
-          it('calling requestClearing should move item into the clearing requested state', async () => {
-            await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+          it('calling requestClearItem should move item into the clearing requested state', async () => {
+            await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
@@ -642,7 +642,7 @@ contract('ArbitrablePermissionList', function(accounts) {
           it('calling challangeBlacklisting should create a dispute', async function() {
             let itemBalance = (await arbitrablePermissionList.items(ARBITRARY_STRING))[4].toNumber();
 
-            await arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+            await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             });
@@ -655,8 +655,8 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.equal(web3.toUtf8(await arbitrablePermissionList.disputeIDToItem(disputeID)), ARBITRARY_STRING)
           });
 
-          it('calling challengeClearing should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+          it('calling challengeClearItem should revert', async () => {
+            await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
@@ -674,7 +674,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             let disputeID;
 
             beforeEach('create a dispute', async function() {
-              await arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               });
@@ -748,14 +748,14 @@ contract('ArbitrablePermissionList', function(accounts) {
           describe('When item in clearing requested state', function() {
 
             beforeEach('prepare pre-conditions', async function() {
-              await arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               });
               await arbitrablePermissionList.executeRequest(ARBITRARY_STRING, {
                 from: partyA
               });
-              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               })
@@ -765,26 +765,26 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0].toNumber(), ITEM_STATUS.CLEARING_REQUESTED)
             });
 
-            it('calling isPermitted should return ' + (blacklist), async () => {
-              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
+            it('calling isPermitted should return ' + (!blacklist), async () => {
+              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
             });
 
-            it('calling requestRegistering should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+            it('calling requestRegisterItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling requestClearing should revert', async function() {
-              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+            it('calling requestClearItem should revert', async function() {
+              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling challengeRegistering should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+            it('calling challengeRegisterItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               }))
@@ -793,7 +793,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             it('calling challangeClearing should create a dispute', async function() {
               let itemBalance = (await arbitrablePermissionList.items(ARBITRARY_STRING))[4].toNumber();
 
-              await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               });
@@ -817,7 +817,7 @@ contract('ArbitrablePermissionList', function(accounts) {
               let disputeID;
 
               beforeEach('create a dispute', async function() {
-                await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+                await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
                   from: partyB,
                   value: stake + arbitrationCost
                 });
@@ -890,7 +890,7 @@ contract('ArbitrablePermissionList', function(accounts) {
           describe('When item in preventive clearing requested state', function() {
 
             beforeEach('prepare pre-conditions', async function() {
-              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               })
@@ -900,35 +900,35 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0].toNumber(), ITEM_STATUS.PREVENTIVE_CLEARING_REQUESTED)
             });
 
-            it('calling isPermitted on a not-disputed item should return ' + (!blacklist), async () => {
-              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
+            it('calling isPermitted on a not-disputed item should return ' + (blacklist), async () => {
+              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
             });
 
             it('calling isPermitted on a disputed item should return ' + (blacklist), async () => {
-              await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               }); // To satisfy disputed pre-condition
 
-              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
+              assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
             });
 
-            it('calling requestRegistering should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestRegistering(ARBITRARY_STRING, {
+            it('calling requestRegisterItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling requestClearing should revert', async function() {
-              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
+            it('calling requestClearItem should revert', async function() {
+              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling challengeRegistering should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegistering(ARBITRARY_STRING, {
+            it('calling challengeRegisterItem should revert', async () => {
+              await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               }))
@@ -937,7 +937,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             it('calling challangeClearing should create a dispute', async function() {
               let itemBalance = (await arbitrablePermissionList.items(ARBITRARY_STRING))[4].toNumber();
 
-              await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               });
@@ -961,7 +961,7 @@ contract('ArbitrablePermissionList', function(accounts) {
               let disputeID;
 
               beforeEach('create a dispute', async function() {
-                await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
+                await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
                   from: partyB,
                   value: stake + arbitrationCost
                 });

--- a/test/arbitrablePermissionList.js
+++ b/test/arbitrablePermissionList.js
@@ -68,7 +68,7 @@ contract('ArbitrablePermissionList', function(accounts) {
     });
 
     before('populate the list', async function (){
-      await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+      await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
         from: partyA,
         value: stake + arbitrationCost
       })
@@ -169,32 +169,32 @@ contract('ArbitrablePermissionList', function(accounts) {
         describe('msg.value restrictions', function() {
           describe('Should revert when msg.value < stake+arbitratorCost', function() {
 
-            it('requestRegisterItem', async () => {
-              await expectThrow(arbitrablePermissionList.requestRegisterItem(
+            it('requestRegistration', async () => {
+              await expectThrow(arbitrablePermissionList.requestRegistration(
                 ARBITRARY_STRING, {
                   from: arbitrator,
                   value: stake + arbitrationCost - 1
                 }))
             });
 
-            it('requestClearItem', async () => {
-              await expectThrow(arbitrablePermissionList.requestClearItem(
+            it('requestClearing', async () => {
+              await expectThrow(arbitrablePermissionList.requestClearing(
                 ARBITRARY_STRING, {
                   from: arbitrator,
                   value: stake + arbitrationCost - 1
                 }))
             });
 
-            it('challengeRegisterItem', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegisterItem(
+            it('challengeRegistration', async () => {
+              await expectThrow(arbitrablePermissionList.challengeRegistration(
                 ARBITRARY_STRING, {
                   from: arbitrator,
                   value: stake + arbitrationCost - 1
                 }))
             });
 
-            it('challengeClearItem', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegisterItem(
+            it('challengeClearing', async () => {
+              await expectThrow(arbitrablePermissionList.challengeRegistration(
                 ARBITRARY_STRING, {
                   from: arbitrator,
                   value: stake + arbitrationCost - 1
@@ -206,12 +206,12 @@ contract('ArbitrablePermissionList', function(accounts) {
         describe('When item.disputed', function() {
 
           beforeEach('prepare pre-conditions to satisfy other requirements', async function() {
-            await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+            await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }); // To satisfy `require(item.status==ItemStatus.Resubmitted || item.status==ItemStatus.Submitted)`
 
-            await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+            await arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }) // To dissatisfy `require(!item.disputed)`
@@ -222,16 +222,16 @@ contract('ArbitrablePermissionList', function(accounts) {
 
             assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[5], true)
           });
-          it('challengeRegisterItem', async () => {
-            await expectThrow(arbitrablePermissionList.challengeRegisterItem(
+          it('challengeRegistration', async () => {
+            await expectThrow(arbitrablePermissionList.challengeRegistration(
               ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
           });
 
-          it('challengeClearItem', async () => {
-            await expectThrow(arbitrablePermissionList.challengeClearItem(
+          it('challengeClearing', async () => {
+            await expectThrow(arbitrablePermissionList.challengeClearing(
               ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
@@ -245,16 +245,16 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.ok((await arbitrablePermissionList.items(ARBITRARY_STRING))[0] < ITEM_STATUS.CLEARING_REQUESTED)
           });
 
-          it('challengeRegisterItem', async function() {
-            await expectThrow(arbitrablePermissionList.challengeRegisterItem(
+          it('challengeRegistration', async function() {
+            await expectThrow(arbitrablePermissionList.challengeRegistration(
               ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
           });
 
-          it('challengeClearItem', async function() {
-            await expectThrow(arbitrablePermissionList.challengeClearItem(
+          it('challengeClearing', async function() {
+            await expectThrow(arbitrablePermissionList.challengeClearing(
               ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
@@ -274,8 +274,8 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
           });
 
-          it('calling requestRegisterItem should move item into the submitted state', async () => {
-            await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+          it('calling requestRegistration should move item into the submitted state', async () => {
+            await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             });
@@ -284,8 +284,8 @@ contract('ArbitrablePermissionList', function(accounts) {
           });
 
           if (!appendOnly) {
-            it('calling requestClearItem should move item into the preventive clearing requested state', async () => {
-              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+            it('calling requestClearing should move item into the preventive clearing requested state', async () => {
+              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -293,8 +293,8 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0].toNumber(), ITEM_STATUS.PREVENTIVE_CLEARING_REQUESTED)
             })
           } else {
-            it('calling requestClearItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+            it('calling requestClearing should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
@@ -303,14 +303,14 @@ contract('ArbitrablePermissionList', function(accounts) {
 
 
           it('calling challangeBlacklisting should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+            await expectThrow(arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
           });
 
           it('calling challangeClearing should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+            await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
@@ -327,14 +327,14 @@ contract('ArbitrablePermissionList', function(accounts) {
           describe('When item in cleared state', function() {
 
             beforeEach('prepare pre-conditions', async function() {
-              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
               await arbitrablePermissionList.executeRequest(ARBITRARY_STRING, {
                 from: arbitrator
               });
-              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -351,8 +351,8 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
             });
 
-            it('calling requestRegisterItem should move item into the resubmitted state', async () => {
-              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+            it('calling requestRegistration should move item into the resubmitted state', async () => {
+              await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -360,22 +360,22 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.items(ARBITRARY_STRING))[0].toNumber(), ITEM_STATUS.RESUBMITTED)
             });
 
-            it('calling requestClearItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+            it('calling requestClearing should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
             });
 
             it('calling challangeBlacklisting should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+              await expectThrow(arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
             });
 
             it('calling challangeClearing should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+              await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
@@ -394,21 +394,21 @@ contract('ArbitrablePermissionList', function(accounts) {
           describe('When item in resubmitted state', function() {
 
             beforeEach('prepare pre-conditions', async function() {
-              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               });
               await arbitrablePermissionList.executeRequest(ARBITRARY_STRING, {
                 from: partyA
               });
-              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               });
               await arbitrablePermissionList.executeRequest(ARBITRARY_STRING, {
                 from: partyB
               });
-              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               })
@@ -423,15 +423,15 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), blacklist)
             });
 
-            it('calling requestRegisterItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+            it('calling requestRegistration should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling requestClearItem should revert', async function() {
-              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+            it('calling requestClearing should revert', async function() {
+              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
@@ -440,7 +440,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             it('calling challengeBlacklisting should create a dispute', async function() {
               let itemBalance = (await arbitrablePermissionList.items(ARBITRARY_STRING))[4].toNumber();
 
-              await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -452,8 +452,8 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal(web3.toUtf8(await arbitrablePermissionList.disputeIDToItem(disputeID)), ARBITRARY_STRING)
             });
 
-            it('calling challengeClearItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+            it('calling challengeClearing should revert', async () => {
+              await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
@@ -471,7 +471,7 @@ contract('ArbitrablePermissionList', function(accounts) {
               let disputeID;
 
               beforeEach('create a dispute', async function() {
-                await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+                await arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
                   from: partyB,
                   value: stake + arbitrationCost
                 });
@@ -543,7 +543,7 @@ contract('ArbitrablePermissionList', function(accounts) {
         describe('When item in registered state', function() {
 
           beforeEach('prepare pre-conditions', async function() {
-            await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+            await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             });
@@ -560,16 +560,16 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
           });
 
-          it('calling requestRegisterItem should revert', async () => {
-            await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+          it('calling requestRegistration should revert', async () => {
+            await expectThrow(arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
           });
 
           if (!appendOnly) {
-            it('calling requestClearItem should move item into the clearing requested state', async () => {
-              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+            it('calling requestClearing should move item into the clearing requested state', async () => {
+              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               });
@@ -579,23 +579,23 @@ contract('ArbitrablePermissionList', function(accounts) {
                 ITEM_STATUS.CLEARING_REQUESTED)
             })
           } else {
-            it('calling requestClearItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+            it('calling requestClearing should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: arbitrator,
                 value: stake + arbitrationCost
               }))
             })
           }
 
-          it('calling challengeRegisterItem should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+          it('calling challengeRegistration should revert', async () => {
+            await expectThrow(arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
           });
 
-          it('calling challengeClearItem should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+          it('calling challengeClearing should revert', async () => {
+            await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
@@ -611,7 +611,7 @@ contract('ArbitrablePermissionList', function(accounts) {
         describe('When item in submitted state', function() {
 
           beforeEach('prepare pre-conditions', async function() {
-            await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+            await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             })
@@ -625,15 +625,15 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
           });
 
-          it('calling requestRegisterItem should revert', async () => {
-            await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+          it('calling requestRegistration should revert', async () => {
+            await expectThrow(arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
           });
 
-          it('calling requestClearItem should move item into the clearing requested state', async () => {
-            await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+          it('calling requestClearing should move item into the clearing requested state', async () => {
+            await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
@@ -642,7 +642,7 @@ contract('ArbitrablePermissionList', function(accounts) {
           it('calling challangeBlacklisting should create a dispute', async function() {
             let itemBalance = (await arbitrablePermissionList.items(ARBITRARY_STRING))[4].toNumber();
 
-            await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+            await arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             });
@@ -655,8 +655,8 @@ contract('ArbitrablePermissionList', function(accounts) {
             assert.equal(web3.toUtf8(await arbitrablePermissionList.disputeIDToItem(disputeID)), ARBITRARY_STRING)
           });
 
-          it('calling challengeClearItem should revert', async () => {
-            await expectThrow(arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+          it('calling challengeClearing should revert', async () => {
+            await expectThrow(arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
               from: arbitrator,
               value: stake + arbitrationCost
             }))
@@ -674,7 +674,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             let disputeID;
 
             beforeEach('create a dispute', async function() {
-              await arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               });
@@ -748,14 +748,14 @@ contract('ArbitrablePermissionList', function(accounts) {
           describe('When item in clearing requested state', function() {
 
             beforeEach('prepare pre-conditions', async function() {
-              await arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               });
               await arbitrablePermissionList.executeRequest(ARBITRARY_STRING, {
                 from: partyA
               });
-              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               })
@@ -769,22 +769,22 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
             });
 
-            it('calling requestRegisterItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+            it('calling requestRegistration should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling requestClearItem should revert', async function() {
-              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+            it('calling requestClearing should revert', async function() {
+              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling challengeRegisterItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+            it('calling challengeRegistration should revert', async () => {
+              await expectThrow(arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               }))
@@ -793,7 +793,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             it('calling challangeClearing should create a dispute', async function() {
               let itemBalance = (await arbitrablePermissionList.items(ARBITRARY_STRING))[4].toNumber();
 
-              await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               });
@@ -817,7 +817,7 @@ contract('ArbitrablePermissionList', function(accounts) {
               let disputeID;
 
               beforeEach('create a dispute', async function() {
-                await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+                await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
                   from: partyB,
                   value: stake + arbitrationCost
                 });
@@ -890,7 +890,7 @@ contract('ArbitrablePermissionList', function(accounts) {
           describe('When item in preventive clearing requested state', function() {
 
             beforeEach('prepare pre-conditions', async function() {
-              await arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               })
@@ -905,7 +905,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             });
 
             it('calling isPermitted on a disputed item should return ' + (blacklist), async () => {
-              await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               }); // To satisfy disputed pre-condition
@@ -913,22 +913,22 @@ contract('ArbitrablePermissionList', function(accounts) {
               assert.equal((await arbitrablePermissionList.isPermitted(ARBITRARY_STRING)), !blacklist)
             });
 
-            it('calling requestRegisterItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.requestRegisterItem(ARBITRARY_STRING, {
+            it('calling requestRegistration should revert', async () => {
+              await expectThrow(arbitrablePermissionList.requestRegistration(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling requestClearItem should revert', async function() {
-              await expectThrow(arbitrablePermissionList.requestClearItem(ARBITRARY_STRING, {
+            it('calling requestClearing should revert', async function() {
+              await expectThrow(arbitrablePermissionList.requestClearing(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               }))
             });
 
-            it('calling challengeRegisterItem should revert', async () => {
-              await expectThrow(arbitrablePermissionList.challengeRegisterItem(ARBITRARY_STRING, {
+            it('calling challengeRegistration should revert', async () => {
+              await expectThrow(arbitrablePermissionList.challengeRegistration(ARBITRARY_STRING, {
                 from: partyB,
                 value: stake + arbitrationCost
               }))
@@ -937,7 +937,7 @@ contract('ArbitrablePermissionList', function(accounts) {
             it('calling challangeClearing should create a dispute', async function() {
               let itemBalance = (await arbitrablePermissionList.items(ARBITRARY_STRING))[4].toNumber();
 
-              await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+              await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
                 from: partyA,
                 value: stake + arbitrationCost
               });
@@ -961,7 +961,7 @@ contract('ArbitrablePermissionList', function(accounts) {
               let disputeID;
 
               beforeEach('create a dispute', async function() {
-                await arbitrablePermissionList.challengeClearItem(ARBITRARY_STRING, {
+                await arbitrablePermissionList.challengeClearing(ARBITRARY_STRING, {
                   from: partyB,
                   value: stake + arbitrationCost
                 });


### PR DESCRIPTION
- The logic in `isPermitted` was flipped. A blacklist contract should return true for everything not on the list and false for everything submitted or registered.
- Some naming changes. We can take or leave these changes. I just made a PR for easier discussion.