### PR TITLE
Refactor: Fix name conflict with struct Dispute

### DIFF
--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -40,7 +40,7 @@ contract Arbitrable{
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
      *  @param _metaEvidenceID Unique identifier of meta-evidence.
      */
-    event Dispute(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID);
+    event DisputeCreated(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID);
 
     /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due to gas considerations).
      *  @param _arbitrator The arbitrator of the contract.


### PR DESCRIPTION
This name conflict becomes a problem when both CentralizedArbitrator and Arbitrable contracts inherited, which is required in AppealableArbitrator.