### PR TITLE
Chore: Replace deprecated package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "minimetoken": "^0.2.0",
-    "zeppelin-solidity": "^1.7.0"
+    "openzeppelin-solidity": "^1.7.0"
   }
 }


### PR DESCRIPTION
Replaced with zeppelin-solidity with openzeppelin-solidity.

See: https://www.npmjs.com/package/zeppelin-solidity