### PR TITLE
refactor(arbitrable): extract arbitrable interface into IArbitrable

### DIFF
--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -6,49 +6,22 @@
 
 pragma solidity ^0.4.15;
 
+import "./IArbitrable.sol";
 import "./Arbitrator.sol";
 
 /** @title Arbitrable
- *  Arbitrable abstract contract.
+ *  Arbitrable abstract contract. This contract covers the typical scenario in which there is one designated arbitrator. It is meant to be the base contract of most concrete arbitrable contract implementations.
  *  When developing arbitrable contracts, we need to:
  *  -Define the action taken when a ruling is received by the contract. We should do so in executeRuling.
  *  -Allow dispute creation. For this a function must:
  *      -Call arbitrator.createDispute.value(_fee)(_choices,_extraData);
  *      -Create the event Dispute(_arbitrator,_disputeID,_rulingOptions);
  */
-contract Arbitrable{
+contract Arbitrable is IArbitrable{
     Arbitrator public arbitrator;
     bytes public arbitratorExtraData; // Extra data to require particular dispute and appeal behaviour.
 
     modifier onlyArbitrator {require(msg.sender == address(arbitrator), "Can only be called by the arbitrator."); _;}
-
-    /** @dev To be emmited when meta-evidence is submitted.
-     *  @param _metaEvidenceID Unique identifier of meta-evidence.
-     *  @param _evidence A link to the meta-evidence JSON.
-     */
-    event MetaEvidence(uint indexed _metaEvidenceID, string _evidence);
-
-    /** @dev To be emmited when a dispute is created to link the correct meta-evidence to the disputeID
-     *  @param _arbitrator The arbitrator of the contract.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _metaEvidenceID Unique identifier of meta-evidence.
-     */
-    event Dispute(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID);
-
-    /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due to gas considerations).
-     *  @param _arbitrator The arbitrator of the contract.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _party The address of the party submiting the evidence. Note that 0x0 refers to evidence not submitted by any party.
-     *  @param _evidence A URI to the evidence JSON file whose name should be its keccak256 hash followed by .json.
-     */
-    event Evidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, address _party, string _evidence);
-
-    /** @dev To be raised when a ruling is given.
-     *  @param _arbitrator The arbitrator giving the ruling.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _ruling The ruling which was given.
-     */
-    event Ruling(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
 
     /** @dev Constructor. Choose the arbitrator.
      *  @param _arbitrator The arbitrator of the contract.

--- a/contracts/standard/arbitration/IArbitrable.sol
+++ b/contracts/standard/arbitration/IArbitrable.sol
@@ -1,0 +1,49 @@
+/**
+ *  @title IArbitrable
+ *  @author Clément Lesaege - <clement@lesaege.com>
+ *  Bug Bounties: This code hasn't undertaken a bug bounty program yet.
+ */
+
+pragma solidity ^0.4.15;
+
+import "./Arbitrator.sol";
+
+/** @title IArbitrable
+ *  Arbitrable interface.
+ */
+interface IArbitrable{
+    /** @dev To be emmited when meta-evidence is submitted.
+     *  @param _metaEvidenceID Unique identifier of meta-evidence.
+     *  @param _evidence A link to the meta-evidence JSON.
+     */
+    event MetaEvidence(uint indexed _metaEvidenceID, string _evidence);
+
+    /** @dev To be emmited when a dispute is created to link the correct meta-evidence to the disputeID
+     *  @param _arbitrator The arbitrator of the contract.
+     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _metaEvidenceID Unique identifier of meta-evidence.
+     */
+    event Dispute(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID);
+
+    /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due to gas considerations).
+     *  @param _arbitrator The arbitrator of the contract.
+     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _party The address of the party submiting the evidence. Note that 0x0 refers to evidence not submitted by any party.
+     *  @param _evidence A link to evidence or if it is short the evidence itself. Can be web link ("http://X"), IPFS ("ipfs:/X") or another storing service (using the URI, see https://en.wikipedia.org/wiki/Uniform_Resource_Identifier ). One usecase of short evidence is to include the hash of the plain English contract.
+     */
+    event Evidence(Arbitrator indexed _arbitrator, uint indexed _disputeID, address _party, string _evidence);
+
+    /** @dev To be raised when a ruling is given.
+     *  @param _arbitrator The arbitrator giving the ruling.
+     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _ruling The ruling which was given.
+     */
+    event Ruling(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
+
+    /** @dev Give a ruling for a dispute. Must be called by the arbitrator.
+     *  The purpose of this function is to ensure that the address calling it has the right to rule on the contract.
+     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _ruling Ruling given by the arbitrator. Note that 0 is reserved for "Not able/wanting to make a decision".
+     */
+    function rule(uint _disputeID, uint _ruling) public;
+}


### PR DESCRIPTION
#142 

This should pave the way for allowing MultipleArbitrableTransaction to inherit from the arbitrable interface.

This is a backward compatible change: as far as the inheritors of Arbitrable are concerned, nothing is changed.

