### PR TITLE
fix(multiple-arbitrable-transaction): require dispute-created instead…

### DIFF
--- a/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
@@ -290,7 +290,7 @@ contract MultipleArbitrableTransaction {
         uint transactionID = disputeID[_disputeID];
         Transaction storage transaction = transactions[transactionID];
         require(msg.sender == address(arbitrator), "The caller must be the arbitrator.");
-        require(transaction.status == Status.Resolved, "The dispute has already been resolved.");
+        require(transaction.status == Status.DisputeCreated, "The dispute has already been resolved.");
 
         emit Ruling(transactionID, Arbitrator(msg.sender), _disputeID, _ruling);
 


### PR DESCRIPTION
#170 

In function `rule`:
```
function rule(uint _disputeID, uint _ruling) public {
    uint transactionID = disputeID[_disputeID];
    Transaction storage transaction = transactions[transactionID];
    require(msg.sender == address(arbitrator), "The caller must be the arbitrator.");
    require(transaction.status == Status.Resolved, "The dispute has already been resolved.");

    emit Ruling(transactionID, Arbitrator(msg.sender), _disputeID, _ruling);

    executeRuling(transactionID, _ruling);
}
```
Before:
`require(transaction.status == Status.Resolved, "The dispute has already been resolved.");`

After:
`require(transaction.status == Status.DisputeCreated, "The dispute has already been resolved.");`

Reason:
Shouldn't the rule function be called when the status is DisputeCreated and no longer after the status is Resolved?