### PR TITLE
fix(multiple-arbitrable-transaction): replace order of statements in …

### DIFF
--- a/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
@@ -253,8 +253,8 @@ contract MultipleArbitrableTransaction {
         Transaction storage transaction = transactions[_transactionID];
         transaction.status = Status.DisputeCreated;
         transaction.arbitrationCost = _arbitrationCost;
-        disputeID[transaction.disputeId] = _transactionID;
         transaction.disputeId = arbitrator.createDispute.value(_arbitrationCost)(AMOUNT_OF_CHOICES, arbitratorExtraData);
+        disputeID[transaction.disputeId] = _transactionID;
         emit Dispute(arbitrator, transaction.disputeId, _transactionID);
     }
 


### PR DESCRIPTION
#170 

In function `raiseDispute`:
```
function raiseDispute(uint _transactionID, uint _arbitrationCost) internal {
    Transaction storage transaction = transactions[_transactionID];
    transaction.status = Status.DisputeCreated;
    transaction.arbitrationCost = _arbitrationCost;
    disputeID[transaction.disputeId] = _transactionID;
    transaction.disputeId = arbitrator.createDispute.value(_arbitrationCost)(AMOUNT_OF_CHOICES, arbitratorExtraData);
    emit Dispute(arbitrator, transaction.disputeId, _transactionID);
}
```
Executing `disputeID[transaction.disputeId] = _transactionID;` before `transaction.disputeId = arbitrator.createDispute.value(_arbitrationCost)(AMOUNT_OF_CHOICES, arbitratorExtraData);` will cause always writing to index zero of disputeID array. So the order of the statements should be reversed.