### PR TITLE
Feat: Review Suggestions

### DIFF
--- a/contracts/standard/permission/ArbitrableAddressList.sol
+++ b/contracts/standard/permission/ArbitrableAddressList.sol
@@ -121,12 +121,6 @@ contract ArbitrableAddressList is PermissionInterface, Arbitrable {
         bool _appealed
     );
 
-    /** @dev Emitted when a deposit is made to challenge a request.
-     *  @param _address The address that has the challenged request.
-     *  @param _challenger The address that paid the deposit.
-     */
-    event ChallengeDepositPlaced(address indexed _address, address indexed _challenger);
-
     /** @dev Emitted when a reimbursements and/or contribution rewards are withdrawn.
      *  @param _address The address from which the withdrawal was made.
      *  @param _contributor The address that sent the contribution.
@@ -296,7 +290,6 @@ contract ArbitrableAddressList is PermissionInterface, Arbitrable {
         request.challengeRewardBalance += request.challengeRewardBalance;
         request.parties[uint(Party.Challenger)] = msg.sender;
         request.challengerDepositTime = now; // Save the time the request left the challenge period and entered the arbitration fees funding period.
-        emit ChallengeDepositPlaced(_address, msg.sender);
 
         // Update the total amount required to fully fund the each side.
         // The amount required for each side is:

--- a/contracts/standard/permission/ArbitrableAddressList.sol
+++ b/contracts/standard/permission/ArbitrableAddressList.sol
@@ -556,7 +556,10 @@ contract ArbitrableAddressList is PermissionInterface, Arbitrable {
                 true,
                 true
             );
-        } else if (round.paidFees[uint(Party.Requester)] >= round.paidFees[uint(Party.Challenger)] && round.sidePendingFunds == Party.Requester) {
+        } else if (
+            round.paidFees[uint(Party.Requester)] >= round.paidFees[uint(Party.Challenger)] &&
+            (round.sidePendingFunds == Party.Requester || round.sidePendingFunds == Party.None)) {
+
             // Notify challenger if he must receive contributions to not lose the case.
             round.sidePendingFunds = Party.Challenger;
             emit WaitingOpponent(
@@ -564,7 +567,10 @@ contract ArbitrableAddressList is PermissionInterface, Arbitrable {
                 Party.Challenger,
                 request.parties[uint(Party.Challenger)]
             );
-        } else if (round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)] && round.sidePendingFunds == Party.Challenger) {
+        } else if (
+            round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)] &&
+            (round.sidePendingFunds == Party.Challenger || round.sidePendingFunds == Party.None)) {
+
             // Notify requester if he must receive contributions to not lose the case.
             round.sidePendingFunds = Party.Requester;
             emit WaitingOpponent(

--- a/contracts/standard/permission/ArbitrableAddressList.sol
+++ b/contracts/standard/permission/ArbitrableAddressList.sol
@@ -270,8 +270,9 @@ contract ArbitrableAddressList is PermissionInterface, Arbitrable {
 
     /** @dev Challenges the latest request of an address. Accepts enough ETH to fund a potential dispute considering the current required amount. Reimburses unused ETH. TRUSTED.
      *  @param _address The address with the request to challenge.
+     *  @param _evidence A link to an evidence using its URI. Ignored if not provided or if not enough funds were raised to create a dispute.
      */
-    function challengeRequest(address _address) external payable {
+    function challengeRequest(address _address, string _evidence) external payable {
         Address storage addr = addresses[_address];
         require(
             addr.status == AddressStatus.RegistrationRequested || addr.status == AddressStatus.ClearingRequested,
@@ -328,6 +329,9 @@ contract ArbitrableAddressList is PermissionInterface, Arbitrable {
 
             request.rounds.length++;
             round.feeRewards -= arbitrationCost;
+
+            if (bytes(_evidence).length > 0)
+                emit Evidence(request.arbitrator, request.disputeID, msg.sender, _evidence);
 
             emit AddressStatusChange(
                 request.parties[uint(Party.Requester)],

--- a/contracts/standard/permission/ArbitrableAddressList.sol
+++ b/contracts/standard/permission/ArbitrableAddressList.sol
@@ -846,7 +846,7 @@ contract ArbitrableAddressList is PermissionInterface, Arbitrable {
         require(request.disputed, "The request is not disputed.");
         require(!request.resolved, "The dispute was resolved.");
 
-        emit Evidence(arbitrator, request.disputeID, msg.sender, _evidence);
+        emit Evidence(request.arbitrator, request.disputeID, msg.sender, _evidence);
     }
 
     // ************************ //

--- a/contracts/standard/permission/ArbitrableTokenList.sol
+++ b/contracts/standard/permission/ArbitrableTokenList.sol
@@ -387,7 +387,7 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
                 Party.Challenger,
                 request.parties[uint(Party.Challenger)]
             );
-        } else if (round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)] && round.sidePendingFunds == Party.Challenger) {
+        } else if (round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)]) {
             // Notify requester if he must receive contributions to not lose the case.
             round.sidePendingFunds = Party.Requester;
             emit WaitingOpponent(
@@ -599,7 +599,10 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
                 true,
                 true
             );
-        } else if (round.paidFees[uint(Party.Requester)] >= round.paidFees[uint(Party.Challenger)] && round.sidePendingFunds == Party.Requester) {
+        } else if (
+            round.paidFees[uint(Party.Requester)] >= round.paidFees[uint(Party.Challenger)] &&
+            (round.sidePendingFunds == Party.Requester || round.sidePendingFunds == Party.None)) {
+
             // Notify challenger if he must receive contributions to not lose the case.
             round.sidePendingFunds = Party.Challenger;
             emit WaitingOpponent(
@@ -607,7 +610,10 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
                 Party.Challenger,
                 request.parties[uint(Party.Challenger)]
             );
-        } else if (round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)] && round.sidePendingFunds == Party.Challenger) {
+        } else if (
+            round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)] &&
+            (round.sidePendingFunds == Party.Challenger || round.sidePendingFunds == Party.None)) {
+
             // Notify requester if he must receive contributions to not lose the case.
             round.sidePendingFunds = Party.Requester;
             emit WaitingOpponent(

--- a/contracts/standard/permission/ArbitrableTokenList.sol
+++ b/contracts/standard/permission/ArbitrableTokenList.sol
@@ -890,7 +890,7 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         require(request.disputed, "The request is not disputed.");
         require(!request.resolved, "The dispute was resolved.");
 
-        emit Evidence(arbitrator, request.disputeID, msg.sender, _evidence);
+        emit Evidence(request.arbitrator, request.disputeID, msg.sender, _evidence);
     }
 
     // ************************ //

--- a/contracts/standard/permission/ArbitrableTokenList.sol
+++ b/contracts/standard/permission/ArbitrableTokenList.sol
@@ -312,8 +312,9 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
 
     /** @dev Challenges the latest request of a token. Accepts enough ETH to fund a potential dispute considering the current required amount. Reimburses unused ETH. TRUSTED.
      *  @param _tokenID The ID of the token with the request to challenge.
+     *  @param _evidence A link to an evidence using its URI. Ignored if not provided or if not enough funds were raised to create a dispute.
      */
-    function challengeRequest(bytes32 _tokenID) external payable {
+    function challengeRequest(bytes32 _tokenID, string _evidence) external payable {
         Token storage token = tokens[_tokenID];
         require(
             token.status == TokenStatus.RegistrationRequested || token.status == TokenStatus.ClearingRequested,
@@ -370,6 +371,9 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
 
             request.rounds.length++;
             round.feeRewards -= arbitrationCost;
+
+            if (bytes(_evidence).length > 0)
+                emit Evidence(request.arbitrator, request.disputeID, msg.sender, _evidence);
 
             emit TokenStatusChange(
                 request.parties[uint(Party.Requester)],

--- a/contracts/standard/permission/ArbitrableTokenList.sol
+++ b/contracts/standard/permission/ArbitrableTokenList.sol
@@ -91,6 +91,7 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         uint[3] requiredForSide; // The total amount required to fully fund each side. It is the summation of the dispute or appeal cost and the fee stake.
         bool[3] requiredForSideSet; // Tracks if the amount of fees required for each side has been set.
         uint feeRewards; // Summation of reimbursable fees and stake rewards available to the parties that made contributions to the side that ultimately wins a dispute.
+        Party sidePendingFunds; // The side that must receive fee contributions to not lose the case.
         mapping(address => uint[3]) contributions; // Maps contributors to their contributions for each side.
     }
 
@@ -114,23 +115,6 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
      *  @param _registrationRequest Whether the request is a registration request. False means it is a clearing request.
      */
     event RequestSubmitted(bytes32 indexed _tokenID, bool indexed _registrationRequest);
-
-    /** @dev Emitted when a party makes a contribution.
-     *  @param _tokenID The ID of the token that received the contribution.
-     *  @param _contributor The address that sent the contribution.
-     *  @param _request The request the contribution was made to.
-     *  @param _round The round the contribution was made to.
-     *  @param _side The side the contribution was made to.
-     *  @param _value The value of the contribution.
-     */
-    event Contribution(
-        bytes32 indexed _tokenID,
-        address indexed _contributor,
-        uint indexed _request,
-        uint _round,
-        Party _side,
-        uint _value
-    );
 
     /**
      *  @dev Emitted when a party makes a request, dispute or appeals are raised or when a request is resolved.
@@ -164,6 +148,13 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
      *  @param _value The value of the reward.
      */
     event RewardWithdrawal(bytes32 indexed _tokenID, address indexed _contributor, uint indexed _request, uint _round, uint _value);
+
+    /** @dev Emitted when a side surpassed the adversary in funding and the opponent must fund his side to not lose the case.
+     *  @param _tokenID The ID of the token with the request in the fee funding period.
+     *  @param _side The side that must receive contributions to not lose the case.
+     *  @param _party The account of the side that must receive contributions to not lose the case.
+     */
+    event WaitingOpponent(bytes32 indexed _tokenID, Party indexed _side, address indexed _party);
 
     /* Storage */
 
@@ -311,15 +302,6 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         round.contributions[msg.sender][uint(Party.Requester)] = contribution;
         round.paidFees[uint(Party.Requester)] = contribution;
         round.feeRewards = contribution;
-        if (contribution > 0)
-            emit Contribution(
-                tokenID,
-                msg.sender,
-                token.requests.length - 1,
-                0,
-                Party.Requester,
-                contribution
-            );
 
         // Reimburse leftover ETH.
         msg.sender.send(remainingETH); // Deliberate use of send in order to not block the contract in case of reverting fallback.
@@ -374,15 +356,6 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         round.contributions[msg.sender][uint(Party.Challenger)] = contribution;
         round.paidFees[uint(Party.Challenger)] = contribution;
         round.feeRewards += contribution;
-        if (contribution > 0)
-            emit Contribution(
-                _tokenID,
-                msg.sender,
-                token.requests.length - 1,
-                0,
-                Party.Challenger,
-                contribution
-            );
 
         // Reimburse leftover ETH.
         msg.sender.send(remainingETH); // Deliberate use of send in order to not block the contract in case of reverting fallback.
@@ -412,6 +385,22 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
                 token.status,
                 true,
                 false
+            );
+        } else if (round.paidFees[uint(Party.Requester)] >= round.paidFees[uint(Party.Challenger)]) {
+            // Notify challenger if he must receive contributions to not lose the case.
+            round.sidePendingFunds = Party.Challenger;
+            emit WaitingOpponent(
+                _tokenID,
+                Party.Challenger,
+                request.parties[uint(Party.Challenger)]
+            );
+        } else if (round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)] && round.sidePendingFunds == Party.Challenger) {
+            // Notify requester if he must receive contributions to not lose the case.
+            round.sidePendingFunds = Party.Requester;
+            emit WaitingOpponent(
+                _tokenID,
+                Party.Requester,
+                request.parties[uint(Party.Requester)]
             );
         }
     }
@@ -462,15 +451,6 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         round.contributions[msg.sender][uint(_side)] += contribution;
         round.paidFees[uint(_side)] += contribution;
         round.feeRewards += contribution;
-        if (contribution > 0)
-            emit Contribution(
-                _tokenID,
-                msg.sender,
-                token.requests.length - 1,
-                0,
-                _side,
-                contribution
-            );
 
         // Reimburse leftover ETH.
         msg.sender.send(remainingETH); // Deliberate use of send in order to not block the contract in case of reverting fallback.
@@ -501,7 +481,24 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
                 true,
                 false
             );
+        } else if (round.paidFees[uint(Party.Requester)] >= round.paidFees[uint(Party.Challenger)] && round.sidePendingFunds == Party.Requester) {
+            // Notify challenger if he must receive contributions to not lose the case.
+            round.sidePendingFunds = Party.Challenger;
+            emit WaitingOpponent(
+                _tokenID,
+                Party.Challenger,
+                request.parties[uint(Party.Challenger)]
+            );
+        } else if (round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)] && round.sidePendingFunds == Party.Challenger) {
+            // Notify requester if he must receive contributions to not lose the case.
+            round.sidePendingFunds = Party.Requester;
+            emit WaitingOpponent(
+                _tokenID,
+                Party.Requester,
+                request.parties[uint(Party.Requester)]
+            );
         }
+
     }
 
     /** @dev Takes up to the total amount required to fund a side of an appeal. Reimburses the rest. Creates an appeal if both sides are fully funded. TRUSTED.
@@ -585,15 +582,6 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         round.contributions[msg.sender][uint(_side)] += contribution;
         round.paidFees[uint(_side)] += contribution;
         round.feeRewards += contribution;
-        if (contribution > 0)
-            emit Contribution(
-                _tokenID,
-                msg.sender,
-                token.requests.length - 1,
-                request.rounds.length - 1,
-                _side,
-                contribution
-            );
 
         // Reimburse leftover ETH.
         msg.sender.send(remainingETH); // Deliberate use of send in order to not block the contract in case of reverting fallback.
@@ -617,6 +605,22 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
                 token.status,
                 true,
                 true
+            );
+        } else if (round.paidFees[uint(Party.Requester)] >= round.paidFees[uint(Party.Challenger)] && round.sidePendingFunds == Party.Requester) {
+            // Notify challenger if he must receive contributions to not lose the case.
+            round.sidePendingFunds = Party.Challenger;
+            emit WaitingOpponent(
+                _tokenID,
+                Party.Challenger,
+                request.parties[uint(Party.Challenger)]
+            );
+        } else if (round.paidFees[uint(Party.Challenger)] > round.paidFees[uint(Party.Requester)] && round.sidePendingFunds == Party.Challenger) {
+            // Notify requester if he must receive contributions to not lose the case.
+            round.sidePendingFunds = Party.Requester;
+            emit WaitingOpponent(
+                _tokenID,
+                Party.Requester,
+                request.parties[uint(Party.Requester)]
             );
         }
     }
@@ -729,7 +733,7 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
 
         emit TokenStatusChange(
             request.parties[uint(Party.Requester)],
-            request.parties[uint(Party.Challenger)],
+            address(0x0),
             _tokenID,
             token.status,
             false,

--- a/contracts/standard/permission/ArbitrableTokenList.sol
+++ b/contracts/standard/permission/ArbitrableTokenList.sol
@@ -134,12 +134,6 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         bool _appealed
     );
 
-    /** @dev Emitted when a deposit is made to challenge a request.
-     *  @param _tokenID The ID of the token that has the challenged request.
-     *  @param _challenger The address that paid the deposit.
-     */
-    event ChallengeDepositPlaced(bytes32 indexed _tokenID, address indexed _challenger);
-
     /** @dev Emitted when a reimbursements and/or contribution rewards are withdrawn.
      *  @param _tokenID The ID of the token from which the withdrawal was made.
      *  @param _contributor The address that sent the contribution.
@@ -338,7 +332,6 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         request.challengeRewardBalance += request.challengeRewardBalance;
         request.parties[uint(Party.Challenger)] = msg.sender;
         request.challengerDepositTime = now; // Save the time the request left the challenge period and entered the arbitration fees funding period.
-        emit ChallengeDepositPlaced(_tokenID, msg.sender);
 
         // Update the total amount required to fully fund the each side.
         // The amount required for each side is:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:sol": "kathari lint:sol",
     "lint:js": "kathari lint:js",
     "lint": "yarn run lint:sol && yarn run lint:js",
-    "test:ganache": "ganache-cli &",
+    "test:ganache": "ganache-cli --gasLimit 8000000 &",
     "test:truffle": "truffle test",
     "test": "run-p test:*",
     "cz": "kathari cz",

--- a/test/arbitrable-address-list.js
+++ b/test/arbitrable-address-list.js
@@ -168,12 +168,12 @@ contract('ArbitrableAddressList', function(accounts) {
     describe('challenge registration', () => {
       beforeEach(async () => {
         await expectThrow(
-          arbitrableAddressList.challengeRequest(submissionAddress, {
+          arbitrableAddressList.challengeRequest(submissionAddress, '', {
             from: partyB
           })
         )
 
-        await arbitrableAddressList.challengeRequest(submissionAddress, {
+        await arbitrableAddressList.challengeRequest(submissionAddress, '', {
           from: partyB,
           value: challengeReward
         })

--- a/test/arbitrable-token-list.js
+++ b/test/arbitrable-token-list.js
@@ -171,10 +171,10 @@ contract('ArbitrableTokenList', function(accounts) {
     describe('challenge registration', () => {
       beforeEach(async () => {
         await expectThrow(
-          arbitrableTokenList.challengeRequest(tokenID, { from: partyB })
+          arbitrableTokenList.challengeRequest(tokenID, '', { from: partyB })
         )
 
-        await arbitrableTokenList.challengeRequest(tokenID, {
+        await arbitrableTokenList.challengeRequest(tokenID, '', {
           from: partyB,
           value: challengeReward
         })

--- a/truffle.js
+++ b/truffle.js
@@ -6,6 +6,14 @@ module.exports = {
   //     gasPrice: 21
   //   }
   // },
+  networks: {
+    test: {
+      host: 'localhost',
+      port: 8545,
+      network_id: '*',
+      gas: 8000000
+    }
+  },
   solc: {
     optimizer: {
       enabled: true,


### PR DESCRIPTION
This removes obsolete events and adds the following features:
- Allow submitting evidence when challenging a request;
- Emit WaitingOpponent whenever a party "passes" the adversary in arbitration fees. This way we can better notify when parties must fund their side to not lose due to being underfunded.

Additionally, this pull request also increases the gas limit of ganache to 8000000.
