### PR TITLE
fix(contracts): eliminate cyclical dependencies

### DIFF
--- a/contracts/standard/arbitration/Arbitrable.sol
+++ b/contracts/standard/arbitration/Arbitrable.sol
@@ -7,6 +7,7 @@
 pragma solidity ^0.4.15;
 
 import "./IArbitrable.sol";
+import "./Arbitrator.sol";
 
 /** @title Arbitrable
  *  Arbitrable abstract contract.

--- a/contracts/standard/arbitration/Arbitrator.sol
+++ b/contracts/standard/arbitration/Arbitrator.sol
@@ -6,7 +6,7 @@
 
 pragma solidity ^0.4.15;
 
-import "./Arbitrable.sol";
+import "./IArbitrable.sol";
 
 /** @title Arbitrator
  *  Arbitrator abstract contract.
@@ -32,18 +32,18 @@ contract Arbitrator {
      *  @param _disputeID ID of the dispute.
      *  @param _arbitrable The contract which created the dispute.
      */
-    event DisputeCreation(uint indexed _disputeID, Arbitrable indexed _arbitrable);
+    event DisputeCreation(uint indexed _disputeID, IArbitrable indexed _arbitrable);
 
     /** @dev To be raised when a dispute can be appealed.
      *  @param _disputeID ID of the dispute.
      */
-    event AppealPossible(uint indexed _disputeID, Arbitrable indexed _arbitrable);
+    event AppealPossible(uint indexed _disputeID, IArbitrable indexed _arbitrable);
 
     /** @dev To be raised when the current ruling is appealed.
      *  @param _disputeID ID of the dispute.
      *  @param _arbitrable The contract which created the dispute.
      */
-    event AppealDecision(uint indexed _disputeID, Arbitrable indexed _arbitrable);
+    event AppealDecision(uint indexed _disputeID, IArbitrable indexed _arbitrable);
 
     /** @dev Create a dispute. Must be called by the arbitrable contract.
      *  Must be paid at least arbitrationCost(_extraData).
@@ -64,7 +64,7 @@ contract Arbitrator {
      *  @param _extraData Can be used to give extra info on the appeal.
      */
     function appeal(uint _disputeID, bytes _extraData) public requireAppealFee(_disputeID,_extraData) payable {
-        emit AppealDecision(_disputeID, Arbitrable(msg.sender));
+        emit AppealDecision(_disputeID, IArbitrable(msg.sender));
     }
 
     /** @dev Compute the cost of appeal. It is recommended not to increase it often, as it can be higly time and gas consuming for the arbitrated contracts to cope with fee augmentation.

--- a/contracts/standard/arbitration/CentralizedArbitrator.sol
+++ b/contracts/standard/arbitration/CentralizedArbitrator.sol
@@ -8,6 +8,7 @@
 
 pragma solidity ^0.4.15;
 
+import "./Arbitrable.sol";
 import "./Arbitrator.sol";
 
 /** @title Centralized Arbitrator

--- a/contracts/standard/arbitration/CentralizedCourt.sol
+++ b/contracts/standard/arbitration/CentralizedCourt.sol
@@ -8,6 +8,7 @@
 pragma solidity ^0.4.15;
 
 import "./Arbitrator.sol";
+import "./Arbitrable.sol";
 
 /** @title Centralized Court
  *  This is a centralized court deciding the result of disputes.

--- a/contracts/standard/arbitration/IArbitrable.sol
+++ b/contracts/standard/arbitration/IArbitrable.sol
@@ -6,8 +6,6 @@
 
 pragma solidity ^0.4.15;
 
-import "./Arbitrator.sol";
-
 /** @title IArbitrable
  *  Arbitrable interface.
  *  When developing arbitrable contracts, we need to:
@@ -25,11 +23,11 @@ interface IArbitrable {
 
     /** @dev To be emmited when a dispute is created to link the correct meta-evidence to the disputeID
      *  @param _arbitrator The arbitrator of the contract.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _disputeID ID of the dispute in the address contract.
      *  @param _metaEvidenceID Unique identifier of meta-evidence.
      *  @param _evidenceGroupID Unique identifier of the evidence group that is linked to this dispute.
      */
-    event Dispute(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID, uint _evidenceGroupID);
+    event Dispute(address indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID, uint _evidenceGroupID);
 
     /** @dev To be raised when evidence are submitted. Should point to the ressource (evidences are not to be stored on chain due to gas considerations).
      *  @param _arbitrator The arbitrator of the contract.
@@ -37,18 +35,18 @@ interface IArbitrable {
      *  @param _party The address of the party submiting the evidence. Note that 0x0 refers to evidence not submitted by any party.
      *  @param _evidence A URI to the evidence JSON file whose name should be its keccak256 hash followed by .json.
      */
-    event Evidence(Arbitrator indexed _arbitrator, uint indexed _evidenceGroupID, address indexed _party, string _evidence);
+    event Evidence(address indexed _arbitrator, uint indexed _evidenceGroupID, address indexed _party, string _evidence);
 
     /** @dev To be raised when a ruling is given.
      *  @param _arbitrator The arbitrator giving the ruling.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _disputeID ID of the dispute in the address contract.
      *  @param _ruling The ruling which was given.
      */
-    event Ruling(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
+    event Ruling(address indexed _arbitrator, uint indexed _disputeID, uint _ruling);
 
     /** @dev Give a ruling for a dispute. Must be called by the arbitrator.
      *  The purpose of this function is to ensure that the address calling it has the right to rule on the contract.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
+     *  @param _disputeID ID of the dispute in the address contract.
      *  @param _ruling Ruling given by the arbitrator. Note that 0 is reserved for "Not able/wanting to make a decision".
      */
     function rule(uint _disputeID, uint _ruling) public;

--- a/contracts/standard/arbitration/MultipleArbitrableTokenTransaction.sol
+++ b/contracts/standard/arbitration/MultipleArbitrableTokenTransaction.sol
@@ -55,40 +55,11 @@ contract MultipleArbitrableTokenTransaction is IArbitrable {
     // *          Events          * //
     // **************************** //
 
-    /** @dev To be emitted when meta-evidence is submitted.
-     *  @param _metaEvidenceID Unique identifier of meta-evidence. Should be the `transactionID`.
-     *  @param _evidence A link to the meta-evidence JSON.
-     */
-    event MetaEvidence(uint indexed _metaEvidenceID, string _evidence);
-
     /** @dev Indicate that a party has to pay a fee or would otherwise be considered as losing.
      *  @param _transactionID The index of the transaction.
      *  @param _party The party who has to pay.
      */
     event HasToPayFee(uint indexed _transactionID, Party _party);
-
-    /** @dev To be raised when evidence is submitted. Should point to the resource (evidences are not to be stored on chain due to gas considerations).
-     *  @param _arbitrator The arbitrator of the contract.
-     *  @param _evidenceGroupID Unique identifier of the group of evidence that relates the evidences to a dispute.
-     *  @param _party The address of the party submitting the evidence. Note that 0 is kept for evidences not submitted by any party.
-     *  @param _evidence A link to an evidence JSON that follows the ERC 1497 Evidence standard (https://github.com/ethereum/EIPs/issues/1497).
-     */
-    event Evidence(Arbitrator indexed _arbitrator, uint indexed _evidenceGroupID, address indexed _party, string _evidence);
-
-    /** @dev To be emitted when a dispute is created to link the correct meta-evidence to the disputeID.
-     *  @param _arbitrator The arbitrator of the contract.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _metaEvidenceID Unique identifier of meta-evidence. Should be the `transactionID`.
-     *  @param _evidenceGroupID Unique identifier of the group of evidence that are linked to this dispute.
-     */
-    event Dispute(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID, uint _evidenceGroupID);
-
-    /** @dev To be raised when a ruling is given.
-     *  @param _arbitrator The arbitrator giving the ruling.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _ruling The ruling which was given.
-     */
-    event Ruling(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
 
     // **************************** //
     // *    Arbitrable functions  * //

--- a/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
+++ b/contracts/standard/arbitration/MultipleArbitrableTransaction.sol
@@ -48,40 +48,11 @@ contract MultipleArbitrableTransaction is IArbitrable {
     // *          Events          * //
     // **************************** //
 
-    /** @dev To be emitted when meta-evidence is submitted.
-     *  @param _metaEvidenceID Unique identifier of meta-evidence. Should be the `transactionID`.
-     *  @param _evidence A link to the meta-evidence JSON that follows the ERC 1497 Evidence standard (https://github.com/ethereum/EIPs/issues/1497).
-     */
-    event MetaEvidence(uint indexed _metaEvidenceID, string _evidence);
-
     /** @dev Indicate that a party has to pay a fee or would otherwise be considered as losing.
      *  @param _transactionID The index of the transaction.
      *  @param _party The party who has to pay.
      */
     event HasToPayFee(uint indexed _transactionID, Party _party);
-
-    /** @dev To be raised when evidence is submitted. Should point to the resource (evidences are not to be stored on chain due to gas considerations).
-     *  @param _arbitrator The arbitrator of the contract.
-     *  @param _evidenceGroupID Unique identifier of the evidence group the evidence belongs to.
-     *  @param _party The address of the party submitting the evidence. Note that 0 is kept for evidences not submitted by any party.
-     *  @param _evidence A link to an evidence JSON that follows the ERC 1497 Evidence standard (https://github.com/ethereum/EIPs/issues/1497).
-     */
-    event Evidence(Arbitrator indexed _arbitrator, uint indexed _evidenceGroupID, address indexed _party, string _evidence);
-
-    /** @dev To be emitted when a dispute is created to link the correct meta-evidence to the disputeID.
-     *  @param _arbitrator The arbitrator of the contract.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _metaEvidenceID Unique identifier of meta-evidence. Should be the transactionID.
-     *  @param _evidenceGroupID Unique identifier of the evidence group that is linked to this dispute.
-     */
-    event Dispute(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _metaEvidenceID, uint _evidenceGroupID);
-
-    /** @dev To be raised when a ruling is given.
-     *  @param _arbitrator The arbitrator giving the ruling.
-     *  @param _disputeID ID of the dispute in the Arbitrator contract.
-     *  @param _ruling The ruling which was given.
-     */
-    event Ruling(Arbitrator indexed _arbitrator, uint indexed _disputeID, uint _ruling);
 
     // **************************** //
     // *    Arbitrable functions  * //

--- a/contracts/standard/permission/ArbitrableTokenList.sol
+++ b/contracts/standard/permission/ArbitrableTokenList.sol
@@ -327,7 +327,7 @@ contract ArbitrableTokenList is PermissionInterface, Arbitrable {
         );
         if (bytes(_evidence).length > 0)
             emit Evidence(request.arbitrator, uint(keccak256(abi.encodePacked(_tokenID,token.requests.length - 1))), msg.sender, _evidence);
-        }
+    }
 
     /** @dev Takes up to the total amount required to fund a side of an appeal. Reimburses the rest. Creates an appeal if both sides are fully funded. TRUSTED.
      *  @param _tokenID The ID of the token with the request to fund.

--- a/contracts/standard/proxy/RealitioArbitratorProxy.sol
+++ b/contracts/standard/proxy/RealitioArbitratorProxy.sol
@@ -8,7 +8,8 @@
 
 pragma solidity ^0.4.24;
 
-import { Arbitrable, Arbitrator } from "../arbitration/Arbitrable.sol";
+import { Arbitrator } from "../arbitration/Arbitrator.sol";
+import { Arbitrable } from "../arbitration/Arbitrable.sol";
 import { Realitio } from "@realitio/realitio-contracts/truffle/contracts/Realitio.sol";
 
 /**


### PR DESCRIPTION
Current dependencies:

```
 +-----------+
 |IArbitrable+----------------+
 +-----+-----+                |
       ^                +-----v----+
       |                |Arbitrator|
       |                +-----+----+
 +-----+-----+                |
 |Arbitrable +<---------------+
 +-----------+
```

A cyclical dependency that makes tools like truffle-flattener useless:

```
$ npx truffle-flattener contracts/standard/arbitration/CentralizedArbitrator.sol
npx: installed 66 in 8.275s
Error: There is a cycle in the dependency graph, can't compute topological ordering. Files:
	contracts/standard/arbitration/CentralizedArbitrator.sol
	/home/hellwolf/Projects/kleros/kleros-interaction/contracts/standard/arbitration/Arbitrator.sol
	/home/hellwolf/Projects/kleros/kleros-interaction/contracts/standard/arbitration/Arbitrable.sol
	/home/hellwolf/Projects/kleros/kleros-interaction/contracts/standard/arbitration/IArbitrable.sol
    at getSortedFilePaths (/home/hellwolf/.npm/_npx/32718/lib/node_modules/truffle-flattener/index.js:95:13)

```

I suggest to make the dependency differently (without having to create a IArbitrator interface):

```
+-----------+
|IArbitrable+<------------------+
+-----+-----+                   |
      ^                   +-----+----+
      |                   |Arbitrator|
      |                   +-----^----+
+-----+-----+                   |
|Arbitrable +-------------------+
+-----------+
```