### PR TITLE
fix:  functions in interfaces should be declared external

### DIFF
--- a/contracts/standard/arbitration/IArbitrable.sol
+++ b/contracts/standard/arbitration/IArbitrable.sol
@@ -51,5 +51,5 @@ interface IArbitrable {
      *  @param _disputeID ID of the dispute in the Arbitrator contract.
      *  @param _ruling Ruling given by the arbitrator. Note that 0 is reserved for "Not able/wanting to make a decision".
      */
-    function rule(uint _disputeID, uint _ruling) public;
+    function rule(uint _disputeID, uint _ruling) external;
 }


### PR DESCRIPTION
To avoid this warning: `@kleros/kleros-interaction/contracts/standard/arbitration/IArbitrable.sol:54:5: Warning: Functions in interfaces should be declared external.`