### PR TITLE
Created BlockhashRNGFallbackRange.sol

### DIFF
--- a/contracts/standard/rng/BlockhashRNGFallbackRange.sol
+++ b/contracts/standard/rng/BlockhashRNGFallbackRange.sol
@@ -1,6 +1,6 @@
  /**
- *  @authors: [@clesaege]
- *  @reviewers: [@remedcu]
+ *  @authors: [@remedcu]
+ *  @reviewers: [@clesaege]
  *  @auditors: []
  *  @bounties: []
  *  @deployments: []
@@ -12,12 +12,12 @@ import "./BlockhashRNG.sol";
 
 /**
  *  @title Random Number Generator using blockhash with fallback from the last 256 blockhash mined.
- *  @author Clément Lesaege - <clement@lesaege.com>
+ *  @author Shebin John - <admin@remedcu.com>
  *
  *  Random Number Generator returning the blockhash with a backup behaviour.
  *  This contract implements the RNG standard and gives parties incentives to save the blockhash to avoid it to become unreachable after 256 blocks.
  *  In case no one called it within the 256 blocks, it returns the blockhash from any one of the last mined 256 blocks.
- *  Thus allowing the contract to still access the blockhash even after 256 blocks.
+ *  Thus allowing the contract to still return a value even after 256 blocks.
  *  Allows saving the random number for use in the future.
  *  The first party to call the save function gets the reward.
  *  This contract must be used when returning 0 is a worse failure mode than returning another blockhash.
@@ -30,11 +30,11 @@ contract BlockHashRNGFallback is BlockHashRNG {
      */
     function saveRN(uint _block) public {
         if (_block < block.number && randomNumber[_block] == 0) {// If the random number is not already set and can be.
-            if (blockhash(_block) != 0x0){ // Normal case.
+            if (blockhash(_block) != 0x0) { // Normal case.
                 randomNumber[_block] = uint(blockhash(_block));
             }
-            else{ // The contract was not called in time. Fallback to returning any one of the blockhash of last mined 256 blocks.
-                randomNumber[_block] = uint(blockhash((block.number - 1) - (block.number - 1 - _block)%256));
+            else { // The contract was not called in time. Fallback to returning any one of the blockhash of last mined 256 blocks.
+                randomNumber[_block] = uint(blockhash((block.number-1) - (block.number-1-_block)%256));
             }
         }
 

--- a/contracts/standard/rng/BlockhashRNGFallbackRange.sol
+++ b/contracts/standard/rng/BlockhashRNGFallbackRange.sol
@@ -1,0 +1,48 @@
+ /**
+ *  @authors: [@clesaege]
+ *  @reviewers: [@remedcu]
+ *  @auditors: []
+ *  @bounties: []
+ *  @deployments: []
+ */
+
+pragma solidity ^0.4.15;
+
+import "./BlockhashRNG.sol";
+
+/**
+ *  @title Random Number Generator using blockhash with fallback from the last 256 blockhash mined.
+ *  @author Clément Lesaege - <clement@lesaege.com>
+ *
+ *  Random Number Generator returning the blockhash with a backup behaviour.
+ *  This contract implements the RNG standard and gives parties incentives to save the blockhash to avoid it to become unreachable after 256 blocks.
+ *  In case no one called it within the 256 blocks, it returns the blockhash from any one of the last mined 256 blocks.
+ *  Thus allowing the contract to still access the blockhash even after 256 blocks.
+ *  Allows saving the random number for use in the future.
+ *  The first party to call the save function gets the reward.
+ *  This contract must be used when returning 0 is a worse failure mode than returning another blockhash.
+ *  Note that if someone calls it within the timeframe, this contracts acts exactly as BlockHashRNG.
+ */
+contract BlockHashRNGFallback is BlockHashRNG {
+
+    /** @dev Save the random number for this blockhash and give the reward to the caller.
+     *  @param _block Block the random number is linked to.
+     */
+    function saveRN(uint _block) public {
+        if (_block < block.number && randomNumber[_block] == 0) {// If the random number is not already set and can be.
+            if (blockhash(_block) != 0x0){ // Normal case.
+                randomNumber[_block] = uint(blockhash(_block));
+            }
+            else{ // The contract was not called in time. Fallback to returning any one of the blockhash of last mined 256 blocks.
+                randomNumber[_block] = uint(blockhash((block.number - 1) - (block.number - 1 - _block)%256));
+            }
+        }
+
+        if (randomNumber[_block] != 0) { // If the random number is set.
+            uint rewardToSend = reward[_block];
+            reward[_block] = 0;
+            msg.sender.send(rewardToSend); // Note that the use of send is on purpose as we don't want to block in case the msg.sender has a fallback issue.
+        }
+    }
+
+}

--- a/contracts/standard/rng/BlockhashRNGFallbackRange.sol
+++ b/contracts/standard/rng/BlockhashRNGFallbackRange.sol
@@ -29,7 +29,7 @@ contract BlockHashRNGFallback is BlockHashRNG {
      *  @param _block Block the random number is linked to.
      */
     function saveRN(uint _block) public {
-        if (_block < block.number && randomNumber[_block] == 0) {// If the random number is not already set and can be.
+        if (_block < block.number && randomNumber[_block] == 0) { // If the random number is not already set and can be.
             // The below equation is valid for all cases (last 256 blockhash of blocks or even earlier than that).
             randomNumber[_block] = uint(blockhash((block.number-1) - (block.number-1-_block)%256));
         }

--- a/contracts/standard/rng/BlockhashRNGFallbackRange.sol
+++ b/contracts/standard/rng/BlockhashRNGFallbackRange.sol
@@ -30,7 +30,7 @@ contract BlockHashRNGFallback is BlockHashRNG {
      */
     function saveRN(uint _block) public {
         if (_block < block.number && randomNumber[_block] == 0) {// If the random number is not already set and can be.
-            // The below equation is valid for all cases (last 256 blockhash of blocks or even earlier than that)
+            // The below equation is valid for all cases (last 256 blockhash of blocks or even earlier than that).
             randomNumber[_block] = uint(blockhash((block.number-1) - (block.number-1-_block)%256));
         }
 

--- a/contracts/standard/rng/BlockhashRNGFallbackRange.sol
+++ b/contracts/standard/rng/BlockhashRNGFallbackRange.sol
@@ -30,7 +30,8 @@ contract BlockHashRNGFallback is BlockHashRNG {
      */
     function saveRN(uint _block) public {
         if (_block < block.number && randomNumber[_block] == 0) { // If the random number is not already set and can be.
-            // The below equation is valid for all cases (last 256 blockhash of blocks or even earlier than that).
+            // Returns the blockhash of _block if accessible (one of the last 256 blocks).
+            // If the blockhash hasn't been saved in time, return a blockhash of a block in range as a fallback.
             randomNumber[_block] = uint(blockhash((block.number-1) - (block.number-1-_block)%256));
         }
 

--- a/contracts/standard/rng/BlockhashRNGFallbackRange.sol
+++ b/contracts/standard/rng/BlockhashRNGFallbackRange.sol
@@ -30,12 +30,8 @@ contract BlockHashRNGFallback is BlockHashRNG {
      */
     function saveRN(uint _block) public {
         if (_block < block.number && randomNumber[_block] == 0) {// If the random number is not already set and can be.
-            if (blockhash(_block) != 0x0) { // Normal case.
-                randomNumber[_block] = uint(blockhash(_block));
-            }
-            else { // The contract was not called in time. Fallback to returning any one of the blockhash of last mined 256 blocks.
-                randomNumber[_block] = uint(blockhash((block.number-1) - (block.number-1-_block)%256));
-            }
+            // The below equation is valid for all cases (last 256 blockhash of blocks or even earlier than that)
+            randomNumber[_block] = uint(blockhash((block.number-1) - (block.number-1-_block)%256));
         }
 
         if (randomNumber[_block] != 0) { // If the random number is set.


### PR DESCRIPTION
Created a new RNG Generator with a Fallback using two of our previous smart contracts:
https://github.com/kleros/kleros-interaction/blob/6ec7f11/contracts/standard/rng/BlockhashRNGFallback.sol
https://github.com/kleros/kleros-interaction/blob/cf43218/contracts/standard/rng/BlockhashRNGFallback.sol

Instead of taking the previous hash like the latter one, we take any one of the last 256 block hashes of the mined blocks. But avoiding the former's vulnerability of allowing anyone to manipulate a `randomNumber` earlier than 256 blocks.