### PR TITLE
Linguo: added getChallengeValue method

### DIFF
--- a/contracts/standard/arbitration/Linguo.sol
+++ b/contracts/standard/arbitration/Linguo.sol
@@ -1,5 +1,5 @@
 /**
- *  @authors: [@unknownunknown1]
+ *  @authors: [@unknownunknown1*]
  *  @reviewers: [@ferittuncer*, @clesaege*, @satello*, @hbarcelos]
  *  @auditors: []
  *  @bounties: []
@@ -575,6 +575,20 @@ contract Linguo is Arbitrable {
             uint price = task.minPrice + (task.maxPrice - task.minPrice) * (now - task.lastInteraction) / task.submissionTimeout;
             uint arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
             deposit = arbitrationCost.addCap((translationMultiplier.mulCap(price)) / MULTIPLIER_DIVISOR);
+        }
+    }
+
+    /** @dev Gets the deposit required for challenging the translation.
+     *  @param _taskID The ID of the task.
+     *  @return deposit The challengers's deposit.
+     */
+    function getChallengeValue(uint _taskID) public view returns (uint deposit) {
+        Task storage task = tasks[_taskID];
+        if (now - task.lastInteraction > reviewTimeout || task.status != Status.AwaitingReview) {
+            deposit = NOT_PAYABLE_VALUE;
+        } else {
+            uint arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
+            deposit = arbitrationCost.addCap((challengeMultiplier.mulCap(task.requesterDeposit)) / MULTIPLIER_DIVISOR);
         }
     }
 

--- a/contracts/standard/arbitration/Linguo.sol
+++ b/contracts/standard/arbitration/Linguo.sol
@@ -1,5 +1,5 @@
 /**
- *  @authors: [@unknownunknown1*]
+ *  @authors: [@unknownunknown1]
  *  @reviewers: [@ferittuncer*, @clesaege*, @satello*, @hbarcelos]
  *  @auditors: []
  *  @bounties: []

--- a/test/linguo.js
+++ b/test/linguo.js
@@ -412,11 +412,9 @@ contract('Linguo', function(accounts) {
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
     await expectThrow(linguo.acceptTranslation(0))
 
-    const task = await linguo.tasks(0)
-    const price = task[6].toNumber()
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -436,10 +434,9 @@ contract('Linguo', function(accounts) {
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
     task = await linguo.tasks(0)
-    const price = task[6].toNumber()
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     const challengeTx = await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -516,10 +513,9 @@ contract('Linguo', function(accounts) {
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
     task = await linguo.tasks(0)
-    const price = task[6].toNumber()
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -574,11 +570,9 @@ contract('Linguo', function(accounts) {
     })
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
-    task = await linguo.tasks(0)
-    const price = task[6].toNumber()
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -633,10 +627,9 @@ contract('Linguo', function(accounts) {
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
     task = await linguo.tasks(0)
-    const price = task[6].toNumber()
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -687,11 +680,9 @@ contract('Linguo', function(accounts) {
     })
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
-    const task = await linguo.tasks(0)
-    const price = task[6].toNumber()
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -805,11 +796,10 @@ contract('Linguo', function(accounts) {
     })
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
-    const task = await linguo.tasks(0)
-    const price = task[6].toNumber()
+    // DEL: const task = await linguo.tasks(0)
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -832,11 +822,10 @@ contract('Linguo', function(accounts) {
     })
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
-    const task = await linguo.tasks(0)
-    const price = task[6].toNumber()
+    // DEL: const task = await linguo.tasks(0)
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -862,10 +851,9 @@ contract('Linguo', function(accounts) {
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
     task = await linguo.tasks(0)
-    const price = task[6].toNumber()
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -926,12 +914,11 @@ contract('Linguo', function(accounts) {
     })
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
-    const task = await linguo.tasks(0)
-    const price = task[6].toNumber()
+    // DEL: const task = await linguo.tasks(0)
 
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -1029,11 +1016,10 @@ contract('Linguo', function(accounts) {
     })
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
-    const task = await linguo.tasks(0)
-    const price = task[6].toNumber()
+    // DEL: const task = await linguo.tasks(0)
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit
@@ -1113,11 +1099,10 @@ contract('Linguo', function(accounts) {
     })
     await linguo.submitTranslation(0, 'ipfs:/X', { from: translator })
 
-    const task = await linguo.tasks(0)
-    const price = task[6].toNumber()
+    // DEL: const task = await linguo.tasks(0)
     // add a small amount because javascript can have small deviations up to several hundreds when operating with large numbers
     const challengerDeposit =
-      arbitrationFee + (challengeMultiplier * price) / MULTIPLIER_DIVISOR + 1000
+      (await linguo.getChallengeValue(0)).toNumber() + 1000
     await linguo.challengeTranslation(0, {
       from: challenger,
       value: challengerDeposit


### PR DESCRIPTION
Adding this method makes sense because it is symmetric to the `getDepositValue` method that already exists.

Beyond helping the UI to figure out the actual required deposit value for a challenge, this could be used as a guard check for other contracts willing to interact with Linguo.