### PR TITLE
perf(RNG): use strict less on pre-merge check

### DIFF
--- a/contracts/standard/rng/BeaconRNG.sol
+++ b/contracts/standard/rng/BeaconRNG.sol
@@ -39,7 +39,7 @@ contract BeaconRNG {
      */
     function getUncorrelatedRN(uint _block) public returns (uint) {
         // Pre-Merge.
-        if (block.difficulty <= 2**64) {
+        if (block.difficulty < 18_446_744_073_709_551_617) { // block.difficulty <= 2**64
             uint baseRN = blockhashRNGFallback.getRN(_block);
             if (baseRN == 0) {
                 return 0;


### PR DESCRIPTION
saves at least 6 gas. "less or equal" does not exist in the evm as a separate opcode, so to get the same effect, the compiler:

- does a `>`, and does a `!` on the result.
- does a `<`, then a `==`, then `||` both. 

both variants need some stack manipulation, and take extra ops. but, you can just to a `<` check of the immediately larger value.